### PR TITLE
Makes Salmiac workflow reusable

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -47,9 +47,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           targets: x86_64-unknown-linux-musl
+          toolchain: nightly
 
       - name: Setup SSH
         run: |

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -47,10 +47,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-musl
-          toolchain: 1.71.0-nightly
 
       - name: Setup SSH
         run: |

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -1,6 +1,18 @@
 name: Build Solution
 
 on:
+  workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      EC2_PRIVATE_SSH_KEY:
+        required: true
+      FORTANIX_API_KEY:
+        required: true
+      OVERLAYFS_UNIT_TEST_API_KEY:
+        required: true
   push:
     branches: [ "master" ]
   pull_request:
@@ -35,9 +47,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           targets: x86_64-unknown-linux-musl
+          toolchain: 1.71.0-nightly
 
       - name: Setup SSH
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /build/
 /artifacts
 /docker/staging
+/tools/container-converter/target
+vsock-proxy/target
+enclave-startup/target

--- a/api-model/Cargo.lock
+++ b/api-model/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "serde"

--- a/run-application-tests.sh
+++ b/run-application-tests.sh
@@ -26,7 +26,7 @@ echo "FORTANIX_API_KEY=$FORTANIX_API_KEY" >> docker-env
 docker pull $TESTS_CONTAINER
 docker save $TESTS_CONTAINER -o salmiac-tests-container.tar.gz
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o BatchMode=yes"
+SSH_OPTS="-o StrictHostKeyChecking=no -o BatchMode=yes -o ServerAliveInterval=60"
 
 echo "######### Copying tests container to Nitro VM. ###############"
 scp $SSH_OPTS salmiac-tests-container.tar.gz $SSH_USERNAME_AWS@$VM_ADDRESS:~/salmiac-tests-container.tar.gz

--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -1302,9 +1302,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "ryu"

--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -1207,9 +1207,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -1836,11 +1836,11 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2128,9 +2128,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "ryu"
@@ -2625,6 +2625,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"


### PR DESCRIPTION
Makes Salmiac workflow reusable (callable from other workflows https://docs.github.com/en/actions/using-workflows/reusing-workflows). This will allow our newly open-sourced `app-test-infra` repository (https://github.com/fortanix/app-test-infra) to call Salmiac workflow as part of it's own CI process.

Why `app-test-infra` needs to run Salmiac CI on every change? Because a change to our testing framework or any change to test applications can potentially break application testing process of Salmiac.

In detail PR adds the capability to make the workflow callable from another workflow by adding the `on call` clause accepting all required secrets as an arguments