### PR TITLE
Adds missing arguments for a reusable workflow

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Pull submodules
         uses: actions/checkout@v3
         with:
-          repository: fortanix/app-test-infra-test
-          token: ${{ secrets.PAT }}
+          repository: fortanix/app-test-infra
           path: tools/app-test-infra
 
       - name: Configure AWS credentials

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Pull main repository
         uses: actions/checkout@v3
+        with:
+          repository: fortanix/salmiac
 
       - name: Pull submodules
         uses: actions/checkout@v3

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -13,6 +13,8 @@ on:
         required: true
       OVERLAYFS_UNIT_TEST_API_KEY:
         required: true
+      PAT:
+        required: true
   push:
     branches: [ "master" ]
   pull_request:
@@ -35,7 +37,8 @@ jobs:
       - name: Pull submodules
         uses: actions/checkout@v3
         with:
-          repository: fortanix/app-test-infra
+          repository: fortanix/app-test-infra-test
+          token: ${{ secrets.PAT }}
           path: tools/app-test-infra
 
       - name: Configure AWS credentials


### PR DESCRIPTION
Adds missing argument (`PAT`) for reusable workflow. Also adds precise name of the `Salmiac` repository during the first stage of the workflow. This allows any caller of the workflow to pull `Salmiac` repository instead of itself (`the caller` repository) when calling this reusable workflow.