### PR TITLE
Update shiplift crate - virtual_size optional field of docker image a…

### DIFF
--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "shiplift"
 version = "0.7.0"
-source = "git+https://github.com/fortanix/shiplift.git#b2168069a42b727cd2a5ae6426166205cae043c7"
+source = "git+https://github.com/fortanix/shiplift.git#de9c9c414583b2390b6c3ac00c5cf15e3613f815"
 dependencies = [
  "base64",
  "byteorder",

--- a/tools/container-converter/src/image.rs
+++ b/tools/container-converter/src/image.rs
@@ -237,7 +237,7 @@ mod tests {
             repo_tags: None,
             repo_digests: None,
             size: 0,
-            virtual_size: 0,
+            virtual_size: Some(0),
         };
 
         let mut input_image = ImageWithDetails { reference, details };

--- a/tools/container-converter/src/image_builder/mod.rs
+++ b/tools/container-converter/src/image_builder/mod.rs
@@ -167,7 +167,7 @@ mod tests {
             repo_tags: None,
             repo_digests: None,
             size: 0,
-            virtual_size: 0,
+            virtual_size: Some(0),
         };
 
         let mut input_image = ImageWithDetails { reference, details };


### PR DESCRIPTION
…ttributes

Issue:
The following converter error was noticed:
```
[2024-03-13T21:47:27Z WARN  container_converter::docker] Encountered error when searching for local image parent-base. SerdeJsonError(Error("missing field `VirtualSize`", line: 1, column: 2749)).
[2024-03-13T21:47:27Z ERROR container_converter] Converter exited with error: Failed retrieving requisite parent-base image. "Image parent-base not found in local repository."
Error: "Failed retrieving requisite parent-base image. \"Image parent-base not found in local repository.\""
```
Upon looking into the docker 24.0 release notes, it's seen that virtual_size field is deprecated (https://docs.docker.com/engine/release-notes/24.0/)  and may not longer be provided by the docker daemon. To fix the above error, an update in the shiplift crate used by the converter was required - https://github.com/fortanix/shiplift/pull/10

This PR picks up the latest changes from the shiplift crate and ensures virtual_size is used as an optional parameter.