### PR TITLE
Add dnsmasq settings file to parent base docker build directory

### DIFF
--- a/docker/parent-base/dnsmasq.d
+++ b/docker/parent-base/dnsmasq.d
@@ -1,0 +1,23 @@
+# If you want dnsmasq to listen for DHCP and DNS requests only on
+# specified interfaces (and the loopback) give the name of the
+# interface (eg eth0) here.
+# Repeat the line for more than one interface.
+interface=fortanix-tap0
+# Or you can specify which interface _not_ to listen on
+#except-interface=
+# Or which to listen on by address (remember to include 127.0.0.1 if
+# you use this.)
+#listen-address=
+# If you want dnsmasq to provide only DNS service on an interface,
+# configure it as shown above, and then use the following line to
+# disable DHCP and TFTP on it.
+no-dhcp-interface=fortanix-tap0
+
+# On systems which support it, dnsmasq binds the wildcard address,
+# even when it is listening on only some interfaces. It then discards
+# requests that it shouldn't reply to. This has the advantage of
+# working even when interfaces come and go and change address. If you
+# want dnsmasq to really bind only the interfaces it is listening on,
+# uncomment this option. About the only time you may need this is when
+# running another nameserver on the same machine.
+bind-interfaces


### PR DESCRIPTION
SALM-559 was fixed in the[ previous PR](https://github.com/fortanix/salmiac/pull/6) but one of the files which was a part of the fix was missing from [the commit.](https://github.com/fortanix/salmiac/pull/6/commits/c4141a092359357c697e9a14d5b71ab6d3d10b9b)

This PR adds that missing file.