### PR TITLE
Check application configuration hash when requesting application configuration

### DIFF
--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "em-client"
 version = "4.0.0"
-source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#8f49c29745e86999610a100ca64c97abc6ce9dbf"
+source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#ee346b8c0516a34f4b059b03ba4277a1293b2cd1"
 dependencies = [
  "base64 0.10.1",
  "bitflags",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "em-client"
 version = "4.0.0"
-source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#ee346b8c0516a34f4b059b03ba4277a1293b2cd1"
+source = "git+https://github.com/fortanix/em-client-rust#feaae6eab3edc421b22d52edc7bc16097cc50719"
 dependencies = [
  "base64 0.10.1",
  "bitflags",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "clap",
  "const_format",
  "em-app",
+ "em-client",
  "env_logger 0.7.1",
  "futures 0.3.16",
  "hyper",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -142,12 +142,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -365,15 +359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +449,7 @@ version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.9.0",
@@ -539,62 +524,34 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "em-app"
 version = "0.4.0"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+source = "git+https://github.com/fortanix/rust-sgx.git#9bcd71b7426ca0154a3445ea2165c0a6a23bc8af"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
- "em-client 3.1.0",
+ "em-client",
  "em-node-agent-client",
  "hyper",
- "mbedtls 0.12.1",
+ "mbedtls",
  "pkix",
  "rustc-serialize",
- "sdkms 0.3.0",
+ "sdkms",
  "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json 1.0.68",
- "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
- "sgx_pkix 0.2.2 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
+ "sgx-isa",
+ "sgx_pkix",
  "url 1.7.2",
  "uuid 0.6.5",
  "uuid 0.8.2",
- "vme-pkix 0.1.1",
- "yasna 0.3.2",
-]
-
-[[package]]
-name = "em-app"
-version = "0.4.0"
-source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
-dependencies = [
- "aws-nitro-enclaves-nsm-api",
- "b64-ct",
- "em-client 3.0.0",
- "em-node-agent-client",
- "hyper",
- "mbedtls 0.9.3",
- "pkix",
- "rustc-serialize",
- "sdkms 0.2.1",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json 1.0.68",
- "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git)",
- "sgx_pkix 0.2.2 (git+https://github.com/fortanix/rust-sgx.git)",
- "url 1.7.2",
- "uuid 0.6.5",
- "uuid 0.7.4",
- "vme-pkix 0.1.0",
+ "vme-pkix",
  "yasna 0.3.2",
 ]
 
 [[package]]
 name = "em-client"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bd923300728ad79f8c36f689f96d928d224524a2120a204fa2bb7801991e7c"
+version = "4.0.0"
+source = "git+https://github.com/fortanix/em-client-rust#60c5764e78a24caa80591d79a260fcd83359319b"
 dependencies = [
  "base64 0.10.1",
  "bitflags",
@@ -603,28 +560,7 @@ dependencies = [
  "hyper",
  "lazy_static 1.4.0",
  "log 0.3.9",
- "mime",
- "serde",
- "serde_derive",
- "serde_ignored",
- "serde_json 1.0.68",
- "url 1.7.2",
- "uuid 0.6.5",
-]
-
-[[package]]
-name = "em-client"
-version = "3.1.0"
-source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#f23e6a89474fd79d1334d6710405730b231c5a33"
-dependencies = [
- "base64 0.10.1",
- "bitflags",
- "chrono",
- "futures 0.1.31",
- "hyper",
- "lazy_static 1.4.0",
- "log 0.3.9",
- "mbedtls 0.9.3",
+ "mbedtls",
  "mime",
  "serde",
  "serde_derive",
@@ -665,7 +601,7 @@ dependencies = [
  "base64 0.13.0",
  "clap",
  "const_format",
- "em-app 0.4.0 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
+ "em-app",
  "env_logger 0.7.1",
  "futures 0.3.16",
  "hyper",
@@ -673,13 +609,13 @@ dependencies = [
  "ipnetwork",
  "lazy_static 1.4.0",
  "log 0.4.14",
- "mbedtls 0.12.1",
+ "mbedtls",
  "nix 0.15.0",
  "parent_lib",
  "pkix",
  "rand 0.8.5",
  "rtnetlink",
- "sdkms 0.3.0",
+ "sdkms",
  "serde",
  "serde_cbor",
  "serde_json 1.0.2",
@@ -1203,24 +1139,6 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a846b1d4b990bc3d900554a12528dfe4b3ab920eac016ee5b314aef4f8e4a9"
-dependencies = [
- "bitflags",
- "byteorder",
- "cc",
- "cfg-if 1.0.0",
- "mbedtls-platform-support",
- "mbedtls-sys-auto",
- "rs-libc",
- "serde",
- "serde_derive",
- "yasna 0.2.2",
-]
-
-[[package]]
-name = "mbedtls"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80ecfbadfdbaa354a1cb85c03317ae679ef15363e15aa251ada8364fa364e6c3"
@@ -1277,7 +1195,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1286,7 +1204,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1295,7 +1213,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1491,7 +1409,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -1502,7 +1420,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits 0.2.14",
 ]
 
@@ -1521,7 +1439,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1578,7 +1496,7 @@ version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1592,7 +1510,7 @@ dependencies = [
  "api-model",
  "async-process",
  "clap",
- "em-app 0.4.0 (git+https://github.com/fortanix/rust-sgx.git)",
+ "em-app",
  "env_logger 0.7.1",
  "etherparse",
  "futures 0.3.16",
@@ -1785,18 +1703,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2055,24 +1963,6 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sdkms"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c843377a2ed87d63e487c7b41b1a82446ab7dc836addd66d63010ea05b14aaf7"
-dependencies = [
- "bitflags",
- "chrono",
- "hyper",
- "log 0.4.14",
- "rustc-serialize",
- "serde",
- "serde_derive",
- "serde_json 1.0.68",
- "url 1.7.2",
- "uuid 0.7.4",
-]
-
-[[package]]
-name = "sdkms"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b12e3cb05862db268118482cbad26eee384b479de1924fe5404028e3444481a"
@@ -2123,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.5"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
 dependencies = [
  "serde",
 ]
@@ -2186,15 +2076,7 @@ dependencies = [
 [[package]]
 name = "sgx-isa"
 version = "0.4.1"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "sgx-isa"
-version = "0.4.1"
-source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
+source = "git+https://github.com/fortanix/rust-sgx.git#9bcd71b7426ca0154a3445ea2165c0a6a23bc8af"
 dependencies = [
  "bitflags",
 ]
@@ -2202,25 +2084,13 @@ dependencies = [
 [[package]]
 name = "sgx_pkix"
 version = "0.2.2"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+source = "git+https://github.com/fortanix/rust-sgx.git#9bcd71b7426ca0154a3445ea2165c0a6a23bc8af"
 dependencies = [
  "byteorder",
  "lazy_static 1.4.0",
  "pkix",
  "quick-error",
- "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
-]
-
-[[package]]
-name = "sgx_pkix"
-version = "0.2.2"
-source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
-dependencies = [
- "byteorder",
- "lazy_static 1.4.0",
- "pkix",
- "quick-error",
- "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git)",
+ "sgx-isa",
 ]
 
 [[package]]
@@ -2433,7 +2303,7 @@ version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bytes 1.0.1",
  "libc",
  "memchr",
@@ -2604,10 +2474,6 @@ name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
- "serde",
-]
 
 [[package]]
 name = "uuid"
@@ -2645,17 +2511,8 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vme-pkix"
-version = "0.1.0"
-source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
-dependencies = [
- "lazy_static 1.4.0",
- "pkix",
-]
-
-[[package]]
-name = "vme-pkix"
 version = "0.1.1"
-source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+source = "git+https://github.com/fortanix/rust-sgx.git#9bcd71b7426ca0154a3445ea2165c0a6a23bc8af"
 dependencies = [
  "lazy_static 1.4.0",
  "pkix",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "em-client"
 version = "4.0.0"
-source = "git+https://github.com/fortanix/em-client-rust#feaae6eab3edc421b22d52edc7bc16097cc50719"
+source = "git+https://github.com/fortanix/em-client-rust#af7d698e603c3f0e728998f3f4612b01af678472"
 dependencies = [
  "base64 0.10.1",
  "bitflags",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -1679,25 +1679,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -1739,68 +1720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -539,27 +539,54 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "em-app"
 version = "0.4.0"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+dependencies = [
+ "aws-nitro-enclaves-nsm-api",
+ "b64-ct",
+ "em-client 3.1.0",
+ "em-node-agent-client",
+ "hyper",
+ "mbedtls 0.12.1",
+ "pkix",
+ "rustc-serialize",
+ "sdkms 0.3.0",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json 1.0.68",
+ "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
+ "sgx_pkix 0.2.2 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
+ "url 1.7.2",
+ "uuid 0.6.5",
+ "uuid 0.8.2",
+ "vme-pkix 0.1.1",
+ "yasna 0.3.2",
+]
+
+[[package]]
+name = "em-app"
+version = "0.4.0"
 source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "b64-ct",
- "em-client",
+ "em-client 3.0.0",
  "em-node-agent-client",
  "hyper",
  "mbedtls 0.9.3",
  "pkix",
  "rustc-serialize",
- "sdkms",
+ "sdkms 0.2.1",
  "serde",
  "serde_bytes",
  "serde_derive",
  "serde_json 1.0.68",
- "sgx-isa",
- "sgx_pkix",
+ "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git)",
+ "sgx_pkix 0.2.2 (git+https://github.com/fortanix/rust-sgx.git)",
  "url 1.7.2",
  "uuid 0.6.5",
  "uuid 0.7.4",
- "vme-pkix",
+ "vme-pkix 0.1.0",
  "yasna 0.3.2",
 ]
 
@@ -576,6 +603,28 @@ dependencies = [
  "hyper",
  "lazy_static 1.4.0",
  "log 0.3.9",
+ "mime",
+ "serde",
+ "serde_derive",
+ "serde_ignored",
+ "serde_json 1.0.68",
+ "url 1.7.2",
+ "uuid 0.6.5",
+]
+
+[[package]]
+name = "em-client"
+version = "3.1.0"
+source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#f23e6a89474fd79d1334d6710405730b231c5a33"
+dependencies = [
+ "base64 0.10.1",
+ "bitflags",
+ "chrono",
+ "futures 0.1.31",
+ "hyper",
+ "lazy_static 1.4.0",
+ "log 0.3.9",
+ "mbedtls 0.9.3",
  "mime",
  "serde",
  "serde_derive",
@@ -616,7 +665,7 @@ dependencies = [
  "base64 0.13.0",
  "clap",
  "const_format",
- "em-app",
+ "em-app 0.4.0 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
  "env_logger 0.7.1",
  "futures 0.3.16",
  "hyper",
@@ -625,13 +674,12 @@ dependencies = [
  "lazy_static 1.4.0",
  "log 0.4.14",
  "mbedtls 0.12.1",
- "mbedtls 0.9.3",
  "nix 0.15.0",
  "parent_lib",
  "pkix",
  "rand 0.8.5",
  "rtnetlink",
- "sdkms",
+ "sdkms 0.3.0",
  "serde",
  "serde_cbor",
  "serde_json 1.0.2",
@@ -1544,7 +1592,7 @@ dependencies = [
  "api-model",
  "async-process",
  "clap",
- "em-app",
+ "em-app 0.4.0 (git+https://github.com/fortanix/rust-sgx.git)",
  "env_logger 0.7.1",
  "etherparse",
  "futures 0.3.16",
@@ -2014,7 +2062,6 @@ dependencies = [
  "bitflags",
  "chrono",
  "hyper",
- "hyper-native-tls",
  "log 0.4.14",
  "rustc-serialize",
  "serde",
@@ -2022,6 +2069,24 @@ dependencies = [
  "serde_json 1.0.68",
  "url 1.7.2",
  "uuid 0.7.4",
+]
+
+[[package]]
+name = "sdkms"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b12e3cb05862db268118482cbad26eee384b479de1924fe5404028e3444481a"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "hyper",
+ "hyper-native-tls",
+ "log 0.4.14",
+ "rustc-serialize",
+ "serde",
+ "serde_json 1.0.68",
+ "url 1.7.2",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2121,9 +2186,29 @@ dependencies = [
 [[package]]
 name = "sgx-isa"
 version = "0.4.1"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "sgx-isa"
+version = "0.4.1"
 source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "sgx_pkix"
+version = "0.2.2"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
+dependencies = [
+ "byteorder",
+ "lazy_static 1.4.0",
+ "pkix",
+ "quick-error",
+ "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147)",
 ]
 
 [[package]]
@@ -2135,7 +2220,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "pkix",
  "quick-error",
- "sgx-isa",
+ "sgx-isa 0.4.1 (git+https://github.com/fortanix/rust-sgx.git)",
 ]
 
 [[package]]
@@ -2525,6 +2610,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2647,15 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 name = "vme-pkix"
 version = "0.1.0"
 source = "git+https://github.com/fortanix/rust-sgx.git#c9028cffb8d80fe325f10eefb26f1f912c235c21"
+dependencies = [
+ "lazy_static 1.4.0",
+ "pkix",
+]
+
+[[package]]
+name = "vme-pkix"
+version = "0.1.1"
+source = "git+https://github.com/fortanix/rust-sgx.git?branch=ns/RTE-147#a8a42b160201cc3ea7d8bc293b2803db559adc67"
 dependencies = [
  "lazy_static 1.4.0",
  "pkix",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "em-client"
 version = "4.0.0"
-source = "git+https://github.com/fortanix/em-client-rust#60c5764e78a24caa80591d79a260fcd83359319b"
+source = "git+https://github.com/fortanix/em-client-rust?branch=ns/RTE-147#8f49c29745e86999610a100ca64c97abc6ce9dbf"
 dependencies = [
  "base64 0.10.1",
  "bitflags",

--- a/vsock-proxy/Cargo.toml
+++ b/vsock-proxy/Cargo.toml
@@ -5,3 +5,11 @@ members = [
     "parent",
     "enclave",
 ]
+
+[workspace.dependencies]
+em-app = { version = "0.4.0" }
+em-client = { version = "4.0.0" }
+
+[patch.crates-io]
+em-app = { git = "https://github.com/fortanix/rust-sgx.git" }
+em-client = { git = "https://github.com/fortanix/em-client-rust" }

--- a/vsock-proxy/Cargo.toml
+++ b/vsock-proxy/Cargo.toml
@@ -12,4 +12,4 @@ em-client = { version = "4.0.0" }
 
 [patch.crates-io]
 em-app = { git = "https://github.com/fortanix/rust-sgx.git" }
-em-client = { git = "https://github.com/fortanix/em-client-rust", branch = "ns/RTE-147" }
+em-client = { git = "https://github.com/fortanix/em-client-rust" }

--- a/vsock-proxy/Cargo.toml
+++ b/vsock-proxy/Cargo.toml
@@ -12,4 +12,4 @@ em-client = { version = "4.0.0" }
 
 [patch.crates-io]
 em-app = { git = "https://github.com/fortanix/rust-sgx.git" }
-em-client = { git = "https://github.com/fortanix/em-client-rust" }
+em-client = { git = "https://github.com/fortanix/em-client-rust", branch = "ns/RTE-147" }

--- a/vsock-proxy/enclave/Cargo.toml
+++ b/vsock-proxy/enclave/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.51"
 base64 = "0.13.0"
 clap = "2.33"
 const_format = "0.2.32"
-em-app = { git = "https://github.com/fortanix/rust-sgx.git", branch = "ns/RTE-147" }
+em-app = { workspace = true }
 env_logger = "0.7"
 futures = "0.3"
 hyper = "0.10"

--- a/vsock-proxy/enclave/Cargo.toml
+++ b/vsock-proxy/enclave/Cargo.toml
@@ -15,19 +15,19 @@ async-trait = "0.1.51"
 base64 = "0.13.0"
 clap = "2.33"
 const_format = "0.2.32"
-em-app = { git = "https://github.com/fortanix/rust-sgx.git" }
+em-app = { git = "https://github.com/fortanix/rust-sgx.git", branch = "ns/RTE-147" }
 env_logger = "0.7"
 futures = "0.3"
 hyper = "0.10"
 interfaces = "0.0.8"
 ipnetwork = { version = "0.18.0", features = ["serde"] }
 log = "0.4"
-mbedtls = { version = "0.9.3" }
+mbedtls = { version = "0.12.1" }
 nix = "0.15.0"
 pkix = "0.1.2"
 rand = "0.8.5"
 rtnetlink = "0.8.0"
-sdkms = { version = "0.2.1", default-features = false, features = ["hyper-native-tls"] }
+sdkms = { version = "0.3", default-features = false, features = ["hyper-native-tls"] }
 serde = { version = "1.0.127", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json =  { git = "https://github.com/fortanix/serde-json.git", branch = "base64_bytes" }

--- a/vsock-proxy/enclave/Cargo.toml
+++ b/vsock-proxy/enclave/Cargo.toml
@@ -16,6 +16,7 @@ base64 = "0.13.0"
 clap = "2.33"
 const_format = "0.2.32"
 em-app = { workspace = true }
+em-client = { workspace = true }
 env_logger = "0.7"
 futures = "0.3"
 hyper = "0.10"

--- a/vsock-proxy/enclave/src/app_configuration.rs
+++ b/vsock-proxy/enclave/src/app_configuration.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
-use std::convert::TryFrom;
+use std::convert::TryInto;
 
 use em_app::utils::models::{
     ApplicationConfigContents, ApplicationConfigExtra, ApplicationConfigSdkmsCredentials, RuntimeAppConfig,
@@ -57,7 +57,10 @@ where
 {
     info!("Requesting application configuration.");
 
-    let app_config_id_raw = <[u8; APPLICATION_CONFIGURATION_ID_LENGTH]>::try_from(app_config_id.as_bytes()).map_err(|err| format!("Cannot convert application config id into an array. Error: {:?}. Perhaps your id isn't {} characters long?", err, APPLICATION_CONFIGURATION_ID_LENGTH))?;
+    let app_config_id_raw: [u8; APPLICATION_CONFIGURATION_ID_LENGTH] = app_config_id
+        .as_bytes()
+        .try_into()
+        .map_err(|err| format!("Cannot convert application config id into an array. Error: {:?}. Perhaps your id isn't {} characters long?", err, APPLICATION_CONFIGURATION_ID_LENGTH))?;
 
     let app_config = api
         .runtime_config_api()
@@ -673,7 +676,7 @@ mod tests {
         let credentials = EmAppCredentials::mock();
         let api: Box<dyn RuntimeConfiguration> = Box::new(MockDataSet { json_data, hash: [0; APPLICATION_CONFIGURATION_ID_LENGTH] });
 
-        let result = api.get_checked_runtime_configuration(&backend_url, &credentials, &[0; APPLICATION_CONFIGURATION_ID_LENGTH]);
+        let result = api.get_runtime_configuration(&backend_url, &credentials, &[0; APPLICATION_CONFIGURATION_ID_LENGTH]);
         assert!(result.is_ok(), "{:?}", result);
 
         result.unwrap()

--- a/vsock-proxy/enclave/src/app_configuration.rs
+++ b/vsock-proxy/enclave/src/app_configuration.rs
@@ -61,7 +61,7 @@ where
 
     let app_config = api
         .runtime_config_api()
-        .get_checked_runtime_configuration(&ccm_backend_url, em_app_credentials, &app_config_id_raw)?;
+        .get_runtime_configuration(&ccm_backend_url, em_app_credentials, &app_config_id_raw)?;
 
     write_runtime_configuration_to_file(&app_config, fs_root)?;
 
@@ -302,7 +302,7 @@ impl ApplicationConfiguration for EmAppApplicationConfiguration {
 pub(crate) struct EmAppRuntimeConfiguration {}
 
 impl RuntimeConfiguration for EmAppRuntimeConfiguration {
-    fn get_checked_runtime_configuration(
+    fn get_runtime_configuration(
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
@@ -321,7 +321,7 @@ impl RuntimeConfiguration for EmAppRuntimeConfiguration {
 }
 
 pub(crate) trait RuntimeConfiguration {
-    fn get_checked_runtime_configuration(
+    fn get_runtime_configuration(
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
@@ -618,7 +618,7 @@ mod tests {
     }
 
     impl RuntimeConfiguration for MockDataSet {
-        fn get_checked_runtime_configuration(
+        fn get_runtime_configuration(
             &self,
             _ccm_backend_url: &CCMBackendUrl,
             _credentials: &EmAppCredentials,
@@ -852,7 +852,7 @@ mod tests {
             hash: correct_hash.clone()
         };
         let backend_url = CCMBackendUrl::default();
-        let runtime_config = api.runtime_config_api().get_checked_runtime_configuration(&backend_url, &credentials, &correct_hash);
+        let runtime_config = api.runtime_config_api().get_runtime_configuration(&backend_url, &credentials, &correct_hash);
 
         assert!(runtime_config.is_ok());
     }
@@ -867,7 +867,7 @@ mod tests {
             hash: correct_hash
         };
         let backend_url = CCMBackendUrl::default();
-        let runtime_config = api.runtime_config_api().get_checked_runtime_configuration(&backend_url, &credentials, &incorrect_hash);
+        let runtime_config = api.runtime_config_api().get_runtime_configuration(&backend_url, &credentials, &incorrect_hash);
 
         assert!(runtime_config.is_err());
     }

--- a/vsock-proxy/enclave/src/app_configuration.rs
+++ b/vsock-proxy/enclave/src/app_configuration.rs
@@ -48,7 +48,7 @@ pub(crate) fn setup_application_configuration<T>(
     ccm_backend_url: &CCMBackendUrl,
     api: T,
     fs_root: &Path,
-    app_config_id: Sha256Hash
+    app_config_id: &Sha256Hash
 ) -> Result<(), String>
 where
     T: ApplicationConfiguration,
@@ -302,7 +302,7 @@ impl RuntimeConfiguration for EmAppRuntimeConfiguration {
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
-        expected_hash: Sha256Hash,
+        expected_hash: &Sha256Hash,
     ) -> Result<RuntimeAppConfig, String> {
         em_app::utils::get_runtime_configuration(
             &ccm_backend_url.host,
@@ -321,7 +321,7 @@ pub(crate) trait RuntimeConfiguration {
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
-        expected_hash: Sha256Hash,
+        expected_hash: &Sha256Hash,
     ) -> Result<RuntimeAppConfig, String>;
 }
 
@@ -623,9 +623,9 @@ mod tests {
             &self,
             _ccm_backend_url: &CCMBackendUrl,
             _credentials: &EmAppCredentials,
-            expected_hash: Sha256Hash,
+            expected_hash: &Sha256Hash,
         ) -> Result<RuntimeAppConfig, String> {
-            if self.hash != expected_hash {
+            if self.hash != *expected_hash {
                 Err(format!("Expected hash: {:?} doesn't equal saved hash: {:?}", expected_hash, self.hash))
             } else {
                 Ok(serde_json::from_str(self.json_data).expect("Failed serializing test json"))
@@ -680,7 +680,7 @@ mod tests {
         let result = api.get_runtime_configuration(
             &backend_url,
             &credentials,
-            Sha256Hash::try_from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").unwrap(),
+            &Sha256Hash::try_from("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").unwrap(),
         );
         assert!(result.is_ok(), "{:?}", result);
 

--- a/vsock-proxy/enclave/src/app_configuration.rs
+++ b/vsock-proxy/enclave/src/app_configuration.rs
@@ -5,21 +5,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::collections::BTreeMap;
-use std::convert::TryInto;
+use std::convert::{TryInto, TryFrom};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use em_app::utils::models::{
-    ApplicationConfigContents, ApplicationConfigExtra, ApplicationConfigSdkmsCredentials,
-    RuntimeAppConfig,
+    ApplicationConfigContents, ApplicationConfigExtra, ApplicationConfigSdkmsCredentials, RuntimeAppConfig,
 };
 use log::{info, warn};
 use mbedtls::alloc::List as MbedtlsList;
 use mbedtls::pk::Pk;
 use mbedtls::x509::Certificate;
 use sdkms::api_model::Blob;
-use shared::models::CCMBackendUrl;
+use shared::models::{CCMBackendUrl};
 
 use crate::certificate::CertificateResult;
 use crate::enclave::write_to_file;
@@ -44,58 +43,77 @@ const CREDENTIALS_FILE: &str = "credentials.bin";
 
 const LOCATION_FILE: &str = "location.txt";
 
-const APPLICATION_CONFIGURATION_ID_LENGTH: usize = 32;
+// https://en.wikipedia.org/wiki/SHA-2
+const SHA256_BYTE_LENGTH: usize = 32;
+
+const SHA256_CHAR_LENGTH: usize = SHA256_BYTE_LENGTH * 2;
+
+#[derive(Debug)]
+pub struct Sha256Hash([u8; SHA256_BYTE_LENGTH]);
+
+impl TryFrom<&str> for Sha256Hash {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() != SHA256_CHAR_LENGTH {
+            return Err(format!("SHA-256 string should be exactly {} characters long, instead got a string of len {}", SHA256_CHAR_LENGTH, value.len()))
+        } else if !(value.chars().all(|c| c.is_ascii_hexdigit())) {
+            return Err(format!("SHA-256 string should contain only hexadecimal characters in the format [0-9a-fA-F], but got {}", value))
+        } else {
+            let mut result = [0u8; SHA256_BYTE_LENGTH];
+
+            for i in 0..SHA256_BYTE_LENGTH {
+                // We iterate input string by chunks of 2 because 1 hex char is half a byte.
+                let chunk = &value[2 * i..2 * i + 2];
+                result[i] = u8::from_str_radix(chunk, 16).map_err(|err| {
+                    format!(
+                        "Invalid hex format for chunk '{}' at position {}. Error {:?}",
+                        chunk, i, err
+                    )
+                })?;
+            }
+
+            Ok(Sha256Hash(result))
+        }
+    }
+}
 
 pub(crate) fn setup_application_configuration<T>(
     em_app_credentials: &EmAppCredentials,
     ccm_backend_url: &CCMBackendUrl,
     api: T,
     fs_root: &Path,
-    app_config_id: &str,
+    app_config_id: &str
 ) -> Result<(), String>
 where
     T: ApplicationConfiguration,
 {
     info!("Requesting application configuration.");
 
-    let app_config_id_raw: [u8; APPLICATION_CONFIGURATION_ID_LENGTH] = app_config_id
+    let app_config_id_raw: [u8; SHA256_BYTE_LENGTH] = app_config_id
         .as_bytes()
         .try_into()
-        .map_err(|err| format!("Cannot convert application config id into an array. Error: {:?}. Perhaps your id isn't {} characters long?", err, APPLICATION_CONFIGURATION_ID_LENGTH))?;
+        .map_err(|err| format!("Cannot convert application config id into an array. Error: {:?}. Perhaps your id isn't {} characters long?", err, SHA256_BYTE_LENGTH))?;
 
-    let app_config = api.runtime_config_api().get_runtime_configuration(
-        &ccm_backend_url,
-        em_app_credentials,
-        &app_config_id_raw,
-    )?;
+    let app_config = api
+        .runtime_config_api()
+        .get_runtime_configuration(&ccm_backend_url, em_app_credentials, &app_config_id_raw)?;
 
     write_runtime_configuration_to_file(&app_config, fs_root)?;
 
-    setup_datasets(
-        &app_config.extra,
-        em_app_credentials,
-        api.dataset_api(),
-        fs_root,
-    )?;
+    setup_datasets(&app_config.extra, em_app_credentials, api.dataset_api(), fs_root)?;
 
     setup_app_configs(&app_config.config.app_config, fs_root)
 }
 
-fn write_runtime_configuration_to_file(
-    app_config: &RuntimeAppConfig,
-    fs_root: &Path,
-) -> Result<(), String> {
-    let data = serde_json::to_string(app_config)
-        .map_err(|err| format!("Failed serializing app config to string. {:?}", err))?;
+fn write_runtime_configuration_to_file(app_config: &RuntimeAppConfig, fs_root: &Path) -> Result<(), String> {
+    let data =
+        serde_json::to_string(app_config).map_err(|err| format!("Failed serializing app config to string. {:?}", err))?;
 
     fs::create_dir_all(fs_root.join(Path::new(APPLICATION_CONFIG_DIR)))
         .map_err(|err| format!("Failed to create app config directory. {:?}", err))?;
 
-    write_to_file(
-        &fs_root.join(Path::new(APPLICATION_CONFIG_FILE)),
-        &data,
-        "application config",
-    )?;
+    write_to_file(&fs_root.join(Path::new(APPLICATION_CONFIG_FILE)), &data, "application config")?;
 
     Ok(())
 }
@@ -136,11 +154,7 @@ where
                 fs::create_dir_all(&files.application_dir)
                     .map_err(|err| format!("Failed to create application directory. {:?}", err))?;
 
-                write_to_file(
-                    &files.location_file,
-                    &application.workflow_domain,
-                    "workflow domain",
-                )?;
+                write_to_file(&files.location_file, &application.workflow_domain, "workflow domain")?;
             }
         }
     }
@@ -148,10 +162,7 @@ where
     Ok(())
 }
 
-fn setup_app_configs(
-    config_map: &BTreeMap<String, ApplicationConfigContents>,
-    fs_root: &Path,
-) -> Result<(), String> {
+fn setup_app_configs(config_map: &BTreeMap<String, ApplicationConfigContents>, fs_root: &Path) -> Result<(), String> {
     for (file, contents_opt) in config_map {
         let file_path = normalize_path_and_make_relative(&file)
             .map_err(|err| format!("Cannot normalize file path in application config. {}", err))?;
@@ -168,22 +179,13 @@ fn setup_app_configs(
             file
         ))?;
 
-        fs::create_dir_all(fs_root.join(dir))
-            .map_err(|err| format!("Failed to create dir for file {}. {:?}", file, err))?;
+        fs::create_dir_all(fs_root.join(dir)).map_err(|err| format!("Failed to create dir for file {}. {:?}", file, err))?;
 
         if let Some(encoded_contents) = &contents_opt.contents {
-            let decoded_contents = base64::decode(encoded_contents).map_err(|err| {
-                format!(
-                    "Failed to base64 decode application config contents. {:?}",
-                    err
-                )
-            })?;
+            let decoded_contents = base64::decode(encoded_contents)
+                .map_err(|err| format!("Failed to base64 decode application config contents. {:?}", err))?;
 
-            write_to_file(
-                &fs_root.join(file_path),
-                &decoded_contents,
-                "application config contents",
-            )?;
+            write_to_file(&fs_root.join(file_path), &decoded_contents, "application config contents")?;
         } else {
             warn!(
                 "Found application config {} with no contents. Created file will be empty.",
@@ -240,8 +242,8 @@ impl ApplicationFiles {
 fn read_root_certificates() -> MbedtlsList<Certificate> {
     let file_contents = include_bytes!(concat!(env!("OUT_DIR"), "/cert_list"));
 
-    let ca_cert_list: Vec<Vec<u8>> = serde_cbor::from_slice(&file_contents[..])
-        .expect("Failed deserializing root certificate list");
+    let ca_cert_list: Vec<Vec<u8>> =
+        serde_cbor::from_slice(&file_contents[..]).expect("Failed deserializing root certificate list");
 
     let mut result = MbedtlsList::<Certificate>::new();
     for i in ca_cert_list {
@@ -253,19 +255,13 @@ fn read_root_certificates() -> MbedtlsList<Certificate> {
 
 fn normalize_path_and_make_relative(raw_path: &str) -> Result<PathBuf, String> {
     if raw_path.ends_with("/") || raw_path.ends_with("/.") {
-        return Err(format!(
-            "Can't normalize path {}. The path ends with '/' or '/.'.",
-            raw_path
-        ));
+        return Err(format!("Can't normalize path {}. The path ends with '/' or '/.'.", raw_path));
     }
 
     let path = Path::new(raw_path);
 
     if !path.has_root() {
-        return Err(format!(
-            "Can't normalize path {}. Path must be absolute. ",
-            path.display()
-        ));
+        return Err(format!("Can't normalize path {}. Path must be absolute. ", path.display()));
     }
 
     // We remove the root ("/") to make the path relative so that it can be joined with the path pointing to the chroot environment
@@ -346,7 +342,7 @@ impl RuntimeConfiguration for EmAppRuntimeConfiguration {
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
-        expected_hash: &[u8; APPLICATION_CONFIGURATION_ID_LENGTH],
+        expected_hash: &[u8; SHA256_BYTE_LENGTH],
     ) -> Result<RuntimeAppConfig, String> {
         em_app::utils::get_runtime_configuration(
             &ccm_backend_url.host,
@@ -355,7 +351,7 @@ impl RuntimeConfiguration for EmAppRuntimeConfiguration {
             credentials.key.clone(),
             credentials.root_certificate.clone(),
             None,
-            expected_hash,
+            expected_hash
         )
     }
 }
@@ -365,7 +361,7 @@ pub(crate) trait RuntimeConfiguration {
         &self,
         ccm_backend_url: &CCMBackendUrl,
         credentials: &EmAppCredentials,
-        expected_hash: &[u8; APPLICATION_CONFIGURATION_ID_LENGTH],
+        expected_hash: &[u8; SHA256_BYTE_LENGTH],
     ) -> Result<RuntimeAppConfig, String>;
 }
 
@@ -406,10 +402,7 @@ pub(crate) struct EmAppCredentials {
 }
 
 impl EmAppCredentials {
-    pub(crate) fn new(
-        mut certificate_info: CertificateResult,
-        skip_server_verify: bool,
-    ) -> Result<Self, String> {
+    pub(crate) fn new(mut certificate_info: CertificateResult, skip_server_verify: bool) -> Result<Self, String> {
         let certificate = {
             certificate_info.certificate.push('\0');
 
@@ -484,14 +477,14 @@ iy6KC991zzvaWY/Ys+q/84Afqa+0qJKQnPuy/7F5GkVdQA/lfbhi
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::convert::TryFrom;
     use std::fs;
     use std::path::Path;
+    use std::convert::TryFrom;
+    use crate::app_configuration::Sha256Hash;
 
     use em_app::utils::models::{
-        ApplicationConfigConnection, ApplicationConfigConnectionApplication,
-        ApplicationConfigConnectionDataset, ApplicationConfigDatasetCredentials,
-        ApplicationConfigExtra, ApplicationConfigSdkmsCredentials, RuntimeAppConfig,
+        ApplicationConfigConnection, ApplicationConfigConnectionApplication, ApplicationConfigConnectionDataset,
+        ApplicationConfigDatasetCredentials, ApplicationConfigExtra, ApplicationConfigSdkmsCredentials, RuntimeAppConfig,
     };
     use sdkms::api_model::Blob;
     use shared::models::CCMBackendUrl;
@@ -499,7 +492,7 @@ mod tests {
     use crate::app_configuration::{
         normalize_path_and_make_relative, setup_app_configs, setup_datasets,
         ApplicationConfiguration, ApplicationFiles, DataSetFiles, EmAppCredentials,
-        RuntimeConfiguration, SdkmsDataset, APPLICATION_CONFIGURATION_ID_LENGTH,
+        RuntimeConfiguration, SdkmsDataset, SHA256_BYTE_LENGTH,
     };
 
     const TEST_FOLDER: &'static str = "/tmp/salm-unit-test";
@@ -627,20 +620,18 @@ mod tests {
 
     impl<'a> Drop for TempDir<'a> {
         fn drop(&mut self) {
-            fs::remove_dir_all(self.0)
-                .expect(&format!("Failed deleting path {}", self.0.display()));
+            fs::remove_dir_all(self.0).expect(&format!("Failed deleting path {}", self.0.display()));
         }
     }
 
     struct MockDataSet {
         pub json_data: &'static str,
-        pub hash: [u8; APPLICATION_CONFIGURATION_ID_LENGTH],
+        pub hash: [u8; SHA256_BYTE_LENGTH],
     }
 
     impl MockDataSet {
         fn application_config_extra() -> ApplicationConfigExtra {
-            let mut connections: BTreeMap<String, BTreeMap<String, ApplicationConfigConnection>> =
-                BTreeMap::new();
+            let mut connections: BTreeMap<String, BTreeMap<String, ApplicationConfigConnection>> = BTreeMap::new();
             let mut app_config: BTreeMap<String, ApplicationConfigConnection> = BTreeMap::new();
             let dataset = ApplicationConfigConnectionDataset {
                 location: "www.test.com".to_string(),
@@ -672,13 +663,10 @@ mod tests {
             &self,
             _ccm_backend_url: &CCMBackendUrl,
             _credentials: &EmAppCredentials,
-            expected_hash: &[u8; APPLICATION_CONFIGURATION_ID_LENGTH],
+            expected_hash: &[u8; SHA256_BYTE_LENGTH],
         ) -> Result<RuntimeAppConfig, String> {
             if self.hash != *expected_hash {
-                Err(format!(
-                    "Expected hash: {:?} doesn't equal saved hash: {:?}",
-                    expected_hash, self.hash
-                ))
+                Err(format!("Expected hash: {:?} doesn't equal saved hash: {:?}", expected_hash, self.hash))
             } else {
                 Ok(serde_json::from_str(self.json_data).expect("Failed serializing test json"))
             }
@@ -712,8 +700,7 @@ mod tests {
     fn setup_runtime_config_correct_json() {
         let config: RuntimeAppConfig = run_setup_runtime_configuration(VALID_RUNTIME_CONF);
 
-        let reference: RuntimeAppConfig =
-            serde_json::from_str(VALID_RUNTIME_CONF).expect("Failed serializing test json");
+        let reference: RuntimeAppConfig = serde_json::from_str(VALID_RUNTIME_CONF).expect("Failed serializing test json");
 
         assert_eq!(config, reference);
     }
@@ -727,13 +714,13 @@ mod tests {
         let credentials = EmAppCredentials::mock();
         let api: Box<dyn RuntimeConfiguration> = Box::new(MockDataSet {
             json_data,
-            hash: [0; APPLICATION_CONFIGURATION_ID_LENGTH],
+            hash: [0; SHA256_BYTE_LENGTH],
         });
 
         let result = api.get_runtime_configuration(
             &backend_url,
             &credentials,
-            &[0; APPLICATION_CONFIGURATION_ID_LENGTH],
+            &[0; SHA256_BYTE_LENGTH],
         );
         assert!(result.is_ok(), "{:?}", result);
 
@@ -746,7 +733,7 @@ mod tests {
         let credentials = EmAppCredentials::mock();
         let api = MockDataSet {
             json_data: VALID_APP_CONF,
-            hash: [0; APPLICATION_CONFIGURATION_ID_LENGTH],
+            hash: [0; SHA256_BYTE_LENGTH],
         };
 
         let result = setup_datasets(&config, &credentials, &api, Path::new("/"));
@@ -763,7 +750,7 @@ mod tests {
         let credentials = EmAppCredentials::mock();
         let api = MockDataSet {
             json_data: VALID_APP_CONF,
-            hash: [0; APPLICATION_CONFIGURATION_ID_LENGTH],
+            hash: [0; SHA256_BYTE_LENGTH],
         };
 
         let test_folder_path = Path::new(TEST_FOLDER).join("datasets");
@@ -774,10 +761,8 @@ mod tests {
         let result = setup_datasets(&config, &credentials, &api, &test_folder.0);
         assert!(result.is_ok(), "{:?}", result);
 
-        let credentials =
-            fs::read_to_string(&files.credentials_file).expect("Failed reading credentials file");
-        let location =
-            fs::read_to_string(&files.location_file).expect("Failed reading locations file");
+        let credentials = fs::read_to_string(&files.credentials_file).expect("Failed reading credentials file");
+        let location = fs::read_to_string(&files.location_file).expect("Failed reading locations file");
 
         assert_eq!(credentials, "OK");
         assert_eq!(location, "www.test.com");
@@ -786,8 +771,7 @@ mod tests {
     #[test]
     fn setup_application_location_correct_pass() {
         let config = {
-            let mut connections: BTreeMap<String, BTreeMap<String, ApplicationConfigConnection>> =
-                BTreeMap::new();
+            let mut connections: BTreeMap<String, BTreeMap<String, ApplicationConfigConnection>> = BTreeMap::new();
             let mut app_config: BTreeMap<String, ApplicationConfigConnection> = BTreeMap::new();
             let application = ApplicationConfigConnectionApplication {
                 workflow_domain: "test_workflow".to_string(),
@@ -809,7 +793,7 @@ mod tests {
         let credentials = EmAppCredentials::mock();
         let api = MockDataSet {
             json_data: VALID_APP_CONF,
-            hash: [0; APPLICATION_CONFIGURATION_ID_LENGTH],
+            hash: [0; SHA256_BYTE_LENGTH],
         };
 
         let test_folder_path = Path::new(TEST_FOLDER).join("appconfig-location");
@@ -821,8 +805,7 @@ mod tests {
         let result = setup_datasets(&config, &credentials, &api, &test_folder.0);
         assert!(result.is_ok(), "{:?}", result);
 
-        let location =
-            fs::read_to_string(&files.location_file).expect("Failed reading locations file");
+        let location = fs::read_to_string(&files.location_file).expect("Failed reading locations file");
 
         assert_eq!(location, "test_workflow");
     }
@@ -835,30 +818,23 @@ mod tests {
 
         assert_eq!(runtime_config.config.app_config.is_empty(), false);
 
-        setup_app_configs(&runtime_config.config.app_config, &test_folder.0)
-            .expect("Failed setting up runtime app config");
+        setup_app_configs(&runtime_config.config.app_config, &test_folder.0).expect("Failed setting up runtime app config");
 
-        let result = fs::read_to_string(
-            test_folder
-                .0
-                .join("opt/fortanix/enclave-os/app-config/rw/app_conf.txt"),
-        )
-        .expect("Failed reading app config file");
+        let result = fs::read_to_string(test_folder.0.join("opt/fortanix/enclave-os/app-config/rw/app_conf.txt"))
+            .expect("Failed reading app config file");
 
         assert_eq!(result, "Hello World")
     }
 
     #[test]
     fn setup_application_configurations_additional_folder_correct_pass() {
-        let runtime_config: RuntimeAppConfig =
-            run_setup_runtime_configuration(VALID_APP_CONF_ADDITIONAL_FOLDER);
+        let runtime_config: RuntimeAppConfig = run_setup_runtime_configuration(VALID_APP_CONF_ADDITIONAL_FOLDER);
         let test_folder_path = Path::new(TEST_FOLDER).join("appconfig-additional-folder");
         let test_folder = TempDir(&test_folder_path);
 
         assert_eq!(runtime_config.config.app_config.is_empty(), false);
 
-        setup_app_configs(&runtime_config.config.app_config, &test_folder.0)
-            .expect("Failed setting up runtime app config");
+        setup_app_configs(&runtime_config.config.app_config, &test_folder.0).expect("Failed setting up runtime app config");
 
         let result = fs::read_to_string(
             &test_folder
@@ -872,8 +848,7 @@ mod tests {
 
     #[test]
     fn setup_application_configurations_incorrect_file_path() {
-        let runtime_config: RuntimeAppConfig =
-            run_setup_runtime_configuration(APP_CONF_INCORRECT_FILE_PATH);
+        let runtime_config: RuntimeAppConfig = run_setup_runtime_configuration(APP_CONF_INCORRECT_FILE_PATH);
 
         assert_eq!(runtime_config.config.app_config.is_empty(), false);
 
@@ -884,47 +859,28 @@ mod tests {
     fn normalize_path_correct_pass() {
         assert_eq!(
             Path::new("❤/✈/☆"),
-            normalize_path_and_make_relative("/❤/✈/☆")
-                .unwrap()
-                .as_path()
+            normalize_path_and_make_relative("/❤/✈/☆").unwrap().as_path()
         );
         assert_eq!(
             Path::new("air/✈/plane"),
-            normalize_path_and_make_relative("/air/✈/plane")
-                .unwrap()
-                .as_path()
+            normalize_path_and_make_relative("/air/✈/plane").unwrap().as_path()
         );
 
         assert_eq!(
             Path::new("a/b"),
-            normalize_path_and_make_relative("/a////b")
-                .unwrap()
-                .as_path()
+            normalize_path_and_make_relative("/a////b").unwrap().as_path()
         );
         assert_eq!(
             Path::new("a/b"),
-            normalize_path_and_make_relative("/a/./././b")
-                .unwrap()
-                .as_path()
+            normalize_path_and_make_relative("/a/./././b").unwrap().as_path()
         );
-        assert_eq!(
-            Path::new("..."),
-            normalize_path_and_make_relative("/...").unwrap().as_path()
-        );
-        assert_eq!(
-            Path::new("a."),
-            normalize_path_and_make_relative("/a.").unwrap().as_path()
-        );
-        assert_eq!(
-            Path::new("a.."),
-            normalize_path_and_make_relative("/a..").unwrap().as_path()
-        );
+        assert_eq!(Path::new("..."), normalize_path_and_make_relative("/...").unwrap().as_path());
+        assert_eq!(Path::new("a."), normalize_path_and_make_relative("/a.").unwrap().as_path());
+        assert_eq!(Path::new("a.."), normalize_path_and_make_relative("/a..").unwrap().as_path());
 
         assert_eq!(
             Path::new("a/b/d/c"),
-            normalize_path_and_make_relative("/a//.///b/d/.///./c")
-                .unwrap()
-                .as_path()
+            normalize_path_and_make_relative("/a//.///b/d/.///./c").unwrap().as_path()
         );
 
         assert!(normalize_path_and_make_relative("a/b/c").is_err());
@@ -936,48 +892,44 @@ mod tests {
     }
 
     #[test]
-    fn check_application_config_id_correct_hash() {
-        let credentials = EmAppCredentials::mock();
-        let correct_hash = <[u8; APPLICATION_CONFIGURATION_ID_LENGTH]>::try_from(
-            "a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTux".as_bytes(),
-        )
-        .unwrap();
-        let api = MockDataSet {
-            json_data: VALID_APP_CONF,
-            hash: correct_hash.clone(),
-        };
-        let backend_url = CCMBackendUrl::default();
-        let runtime_config = api.runtime_config_api().get_runtime_configuration(
-            &backend_url,
-            &credentials,
-            &correct_hash,
-        );
+    fn test_valid_sha256_hash() {
+        let valid_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let hash = Sha256Hash::try_from(valid_sha256);
 
-        assert!(runtime_config.is_ok());
+        assert!(hash.is_ok());
+        let hash = hash.unwrap();
+        assert_eq!(hash.0.len(), SHA256_BYTE_LENGTH);
+        assert_eq!(
+            hash.0,
+            [
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55
+            ]
+        );
     }
 
     #[test]
-    fn check_application_config_id_incorrect_hash() {
-        let credentials = EmAppCredentials::mock();
-        let correct_hash = <[u8; APPLICATION_CONFIGURATION_ID_LENGTH]>::try_from(
-            "a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTux".as_bytes(),
-        )
-        .unwrap();
-        let incorrect_hash = <[u8; APPLICATION_CONFIGURATION_ID_LENGTH]>::try_from(
-            "Xy9Wq2rT6vZa8Lc1Pd0BmJk4Gh7UfVsN".as_bytes(),
-        )
-        .unwrap();
-        let api = MockDataSet {
-            json_data: VALID_APP_CONF,
-            hash: correct_hash,
-        };
-        let backend_url = CCMBackendUrl::default();
-        let runtime_config = api.runtime_config_api().get_runtime_configuration(
-            &backend_url,
-            &credentials,
-            &incorrect_hash,
-        );
+    fn test_invalid_length_sha256_hash() {
+        let invalid_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852"; // 62 characters
+        let hash = Sha256Hash::try_from(invalid_sha256);
 
-        assert!(runtime_config.is_err());
+        assert!(hash.is_err());
+    }
+
+    #[test]
+    fn test_invalid_hex_sha256_hash() {
+        let invalid_sha256 = "X3b0c44298Lc1c149afbf4c8996fb92427XX41e4649b934WW495991b7852Y855";
+        let hash = Sha256Hash::try_from(invalid_sha256);
+
+        assert!(hash.is_err());
+    }
+
+    #[test]
+    fn test_empty_sha256_hash() {
+        let empty_sha256 = "";
+        let hash = Sha256Hash::try_from(empty_sha256);
+
+        assert!(hash.is_err());
     }
 }

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -20,8 +20,8 @@ use futures::{AsyncBufReadExt, StreamExt};
 use log::{debug, info, warn};
 use nix::net::if_::if_nametoindex;
 use shared::models::{
-    ApplicationConfiguration, NBDConfiguration, NetworkDeviceSettings, PrivateNetworkDeviceSettings, SetupMessages,
-    UserProgramExitStatus,
+    ApplicationConfiguration, NBDConfiguration, NetworkDeviceSettings,
+    PrivateNetworkDeviceSettings, SetupMessages, UserProgramExitStatus,
 };
 use shared::netlink::arp::NetlinkARP;
 use shared::netlink::route::NetlinkRoute;
@@ -29,8 +29,8 @@ use shared::netlink::{Netlink, NetlinkCommon};
 use shared::socket::{AsyncReadLvStream, AsyncWriteLvStream};
 use shared::tap::{create_async_tap_device, start_tap_loops, tap_device_config};
 use shared::{
-    cleanup_tokio_tasks, extract_enum_value, with_background_tasks, AppLogPortInfo, StreamType, HOSTNAME_FILE, HOSTS_FILE,
-    NS_SWITCH_FILE, VSOCK_PARENT_CID,
+    cleanup_tokio_tasks, extract_enum_value, with_background_tasks, AppLogPortInfo, StreamType,
+    HOSTNAME_FILE, HOSTS_FILE, NS_SWITCH_FILE, VSOCK_PARENT_CID,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -38,13 +38,21 @@ use tokio::task::JoinHandle;
 use tokio_vsock::{VsockStream as AsyncVsockStream, VsockStream};
 use tun::{AsyncDevice, Device};
 
-use crate::app_configuration::{setup_application_configuration, EmAppApplicationConfiguration, EmAppCredentials};
-use crate::certificate::{create_signer_key, default_certificate, request_certificate, write_certificate, CSRApi, CertificateResult, CertificateWithPath, EmAppCSRApi, DEFAULT_CERT_DIR, DEFAULT_CERT_RSA_KEY_SIZE};
+use crate::app_configuration::{
+    setup_application_configuration, EmAppApplicationConfiguration, EmAppCredentials,
+};
+use crate::certificate::{
+    create_signer_key, default_certificate, request_certificate, write_certificate, CSRApi,
+    CertificateResult, CertificateWithPath, EmAppCSRApi, DEFAULT_CERT_DIR,
+    DEFAULT_CERT_RSA_KEY_SIZE,
+};
 use crate::file_system::{
-    close_dm_crypt_device, close_dm_verity_volume, copy_dns_file_to_mount, copy_startup_binary_to_mount,
-    create_fortanix_directories, create_overlay_dirs, fetch_fs_mount_options, get_available_encrypted_space,
-    mount_file_system_nodes, mount_overlay_fs, mount_read_only_file_system, mount_read_write_file_system, run_nbd_client,
-    setup_dm_verity, unmount_file_system_nodes, unmount_overlay_fs, DMVerityConfig, FileSystemNode, ENCLAVE_FS_OVERLAY_ROOT,
+    close_dm_crypt_device, close_dm_verity_volume, copy_dns_file_to_mount,
+    copy_startup_binary_to_mount, create_fortanix_directories, create_overlay_dirs,
+    fetch_fs_mount_options, get_available_encrypted_space, mount_file_system_nodes,
+    mount_overlay_fs, mount_read_only_file_system, mount_read_write_file_system, run_nbd_client,
+    setup_dm_verity, unmount_file_system_nodes, unmount_overlay_fs, DMVerityConfig, FileSystemNode,
+    ENCLAVE_FS_OVERLAY_ROOT,
 };
 
 const STARTUP_BINARY: &str = "/enclave-startup";
@@ -61,7 +69,10 @@ const FILE_SYSTEM_NODES: &'static [FileSystemNode] = &[
     FileSystemNode::File(NS_SWITCH_FILE),
 ];
 
-pub(crate) async fn run(vsock_port: u32, settings_path: &Path) -> Result<UserProgramExitStatus, String> {
+pub(crate) async fn run(
+    vsock_port: u32,
+    settings_path: &Path,
+) -> Result<UserProgramExitStatus, String> {
     let mut parent_port = connect_to_parent_async(vsock_port).await?;
 
     let (setup_result, networking_setup_result) = startup(&mut parent_port, settings_path).await?;
@@ -84,7 +95,11 @@ pub(crate) async fn run(vsock_port: u32, settings_path: &Path) -> Result<UserPro
             &mut parent_port,
             EmAppCSRApi {},
             &setup_result.app_config.id,
-            &mut setup_result.enclave_manifest.user_config.certificate_config.clone(),
+            &mut setup_result
+                .enclave_manifest
+                .user_config
+                .certificate_config
+                .clone(),
             Path::new(ENCLAVE_FS_OVERLAY_ROOT),
             skip_def_cert_req,
         )
@@ -93,23 +108,32 @@ pub(crate) async fn run(vsock_port: u32, settings_path: &Path) -> Result<UserPro
         let fs_setup_config = FileSystemSetupConfig {
             enclave_manifest: &setup_result.enclave_manifest,
             env_vars: &setup_result.env_vars,
-            cert_list: certificate_info.get_mut(0).map(|e| &mut e.certificate_result),
+            cert_list: certificate_info
+                .get_mut(0)
+                .map(|e| &mut e.certificate_result),
         };
         setup_file_system(&mut parent_port, FileSystemSetupApiImpl {}, fs_setup_config).await?;
 
         for certificate in &mut certificate_info {
             write_certificate(
                 certificate,
-                Some(Path::new(ENCLAVE_FS_OVERLAY_ROOT).join(DEFAULT_CERT_DIR.strip_prefix("/").unwrap_or_default())),
+                Some(
+                    Path::new(ENCLAVE_FS_OVERLAY_ROOT)
+                        .join(DEFAULT_CERT_DIR.strip_prefix("/").unwrap_or_default()),
+                ),
             )?;
         }
 
-        let first_certificate = certificate_info.into_iter().next().map(|e| e.certificate_result);
+        let first_certificate = certificate_info
+            .into_iter()
+            .next()
+            .map(|e| e.certificate_result);
 
         setup_app_configuration(&setup_result.app_config, first_certificate)?;
 
         let log_conn_addrs = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::AppLogPort(addr) => addr)?;
-        let exit_status = start_and_await_user_program_return(setup_result, hostname, log_conn_addrs).await?;
+        let exit_status =
+            start_and_await_user_program_return(setup_result, hostname, log_conn_addrs).await?;
 
         cleanup_fs().await?;
 
@@ -132,7 +156,12 @@ fn enable_loopback_network_interface() -> Result<(), String> {
             warn!("Loopback interface is not present inside an enclave!");
             return Ok(());
         }
-        Err(err) => return Err(format!("Failed accessing loopback network interface. {:?}", err)),
+        Err(err) => {
+            return Err(format!(
+                "Failed accessing loopback network interface. {:?}",
+                err
+            ))
+        }
     };
 
     loopback_interface
@@ -156,21 +185,24 @@ async fn startup(
 
     debug!("Received enclave manifest {:?}", enclave_manifest);
 
-    let mut runtime_env_vars = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::EnvVariables(e) => e)?;
+    let mut runtime_env_vars =
+        extract_enum_value!(parent_port.read_lv().await?, SetupMessages::EnvVariables(e) => e)?;
     let mut env_vars = convert_to_tuples(&enclave_manifest.env_vars)?;
     // TODO: Filter runtime env vars based on which variables can be overriden/restricted. This
     // configuration must be set at conversion time.
     env_vars.append(&mut runtime_env_vars);
 
-    let mut extra_user_program_args =
-        extract_enum_value!(parent_port.read_lv().await?, SetupMessages::ExtraUserProgramArguments(e) => e)?;
+    let mut extra_user_program_args = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::ExtraUserProgramArguments(e) => e)?;
 
     if enclave_manifest.is_debug {
         let existing_arguments = &mut enclave_manifest.user_config.user_program_config.arguments;
 
         existing_arguments.append(&mut extra_user_program_args);
 
-        debug!("Running user program with the args - {:?}", existing_arguments);
+        debug!(
+            "Running user program with the args - {:?}",
+            existing_arguments
+        );
     }
 
     let app_config = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::ApplicationConfig(e) => e)?;
@@ -193,7 +225,10 @@ fn convert_to_tuples(env_strs: &Vec<String>) -> Result<Vec<(String, String)>, St
         let pair = env.split_once("=");
         match pair {
             None => {
-                info!("Env string doesn't contain equal sign separating key value pair - {:?}", env);
+                info!(
+                    "Env string doesn't contain equal sign separating key value pair - {:?}",
+                    env
+                );
             }
             Some(e) => {
                 res.push((e.0.to_string(), e.1.to_string()));
@@ -225,7 +260,11 @@ fn setup_app_configuration(
     }
 }
 
-pub(crate) async fn setup_file_system<'a, Socket: AsyncWrite + AsyncRead + Unpin + Send, Api: FileSystemSetupApi<'a>>(
+pub(crate) async fn setup_file_system<
+    'a,
+    Socket: AsyncWrite + AsyncRead + Unpin + Send,
+    Api: FileSystemSetupApi<'a>,
+>(
     parent_socket: &mut Socket,
     api: Api,
     setup_config: FileSystemSetupConfig<'a>,
@@ -235,7 +274,9 @@ pub(crate) async fn setup_file_system<'a, Socket: AsyncWrite + AsyncRead + Unpin
 
     let space = api.setup(nbd_config, setup_config).await?;
 
-    parent_socket.write_lv(&SetupMessages::EncryptedSpaceAvailable(space)).await?;
+    parent_socket
+        .write_lv(&SetupMessages::EncryptedSpaceAvailable(space))
+        .await?;
 
     Ok(())
 }
@@ -250,13 +291,21 @@ pub struct FileSystemSetupConfig<'a> {
 
 #[async_trait]
 pub trait FileSystemSetupApi<'a> {
-    async fn setup(&self, nbd_config: NBDConfiguration, arg: FileSystemSetupConfig<'a>) -> Result<usize, String>;
+    async fn setup(
+        &self,
+        nbd_config: NBDConfiguration,
+        arg: FileSystemSetupConfig<'a>,
+    ) -> Result<usize, String>;
 }
 
 struct FileSystemSetupApiImpl {}
 #[async_trait]
 impl<'a> FileSystemSetupApi<'a> for FileSystemSetupApiImpl {
-    async fn setup(&self, nbd_config: NBDConfiguration, arg: FileSystemSetupConfig<'a>) -> Result<usize, String> {
+    async fn setup(
+        &self,
+        nbd_config: NBDConfiguration,
+        arg: FileSystemSetupConfig<'a>,
+    ) -> Result<usize, String> {
         let enclave_manifest = arg.enclave_manifest;
         let env_vars = arg.env_vars;
         let cert_list = arg.cert_list;
@@ -282,7 +331,12 @@ impl<'a> FileSystemSetupApi<'a> for FileSystemSetupApiImpl {
         mount_read_only_file_system().await?;
         info!("Finished read only file system mount.");
 
-        mount_read_write_file_system(env_vars, cert_list, enclave_manifest.enable_overlay_filesystem_persistence).await?;
+        mount_read_write_file_system(
+            env_vars,
+            cert_list,
+            enclave_manifest.enable_overlay_filesystem_persistence,
+        )
+        .await?;
         info!("Finished read/write file system mount.");
 
         mount_overlay_fs().await?;
@@ -323,10 +377,14 @@ async fn send_user_program_exit_status(
     vsock: &mut VsockStream,
     exit_status: Result<UserProgramExitStatus, String>,
 ) -> Result<(), String> {
-    vsock.write_lv(&SetupMessages::UserProgramExit(exit_status)).await
+    vsock
+        .write_lv(&SetupMessages::UserProgramExit(exit_status))
+        .await
 }
 
-fn start_background_tasks(tap_devices: Vec<TapDeviceInfo>) -> FuturesUnordered<JoinHandle<Result<(), String>>> {
+fn start_background_tasks(
+    tap_devices: Vec<TapDeviceInfo>,
+) -> FuturesUnordered<JoinHandle<Result<(), String>>> {
     let result = FuturesUnordered::new();
 
     for tap_device in tap_devices {
@@ -344,14 +402,20 @@ async fn start_and_await_user_program_return(
     hostname: String,
     log_conn_addrs: Vec<AppLogPortInfo>,
 ) -> Result<UserProgramExitStatus, String> {
-    let user_program = tokio::spawn(start_user_program(enclave_setup_result, hostname, log_conn_addrs));
+    let user_program = tokio::spawn(start_user_program(
+        enclave_setup_result,
+        hostname,
+        log_conn_addrs,
+    ));
 
     user_program
         .await
         .map_err(|err| format!("Join error in user program wait loop. {:?}", err))?
 }
 
-async fn connect_to_log_ports(log_addrs: Vec<AppLogPortInfo>) -> Result<Vec<(TcpStream, StreamType)>, String> {
+async fn connect_to_log_ports(
+    log_addrs: Vec<AppLogPortInfo>,
+) -> Result<Vec<(TcpStream, StreamType)>, String> {
     let mut res: Vec<(TcpStream, StreamType)> = vec![];
     for log_info in log_addrs {
         let stream = TcpStream::connect(log_info.sock_addr).await.map_err(|e| {
@@ -360,7 +424,10 @@ async fn connect_to_log_ports(log_addrs: Vec<AppLogPortInfo>) -> Result<Vec<(Tcp
                 log_info.sock_addr, e
             )
         })?;
-        info!("Connected to parent on {:?} for stream {:?}", stream, log_info.stream_type);
+        info!(
+            "Connected to parent on {:?} for stream {:?}",
+            stream, log_info.stream_type
+        );
         res.push((stream, log_info.stream_type));
     }
     Ok(res)
@@ -423,7 +490,10 @@ async fn start_user_program(
     hostname: String,
     log_conn_addrs: Vec<AppLogPortInfo>,
 ) -> Result<UserProgramExitStatus, String> {
-    let user_program = enclave_setup_result.enclave_manifest.user_config.user_program_config;
+    let user_program = enclave_setup_result
+        .enclave_manifest
+        .user_config
+        .user_program_config;
     let is_debug_shell = enclave_setup_result
         .env_vars
         .contains(&(DEBUG_SHELL_ENV_VAR.to_string(), "true".to_string()));
@@ -453,7 +523,8 @@ async fn start_user_program(
     } else {
         // We have to recreate /run/sshd because it is setup as a `tmpfs` by a nitro kernel.
         if is_debug_shell {
-            fs::create_dir_all("/run/sshd").map_err(|err| format!("Failed creating dir /run/sshd. {:?}", err))?;
+            fs::create_dir_all("/run/sshd")
+                .map_err(|err| format!("Failed creating dir /run/sshd. {:?}", err))?;
         }
 
         let mut client_command = Command::new(user_program.entry_point.clone());
@@ -463,7 +534,10 @@ async fn start_user_program(
         client_command
     };
 
-    info!("Setting the following env vars {:?}", enclave_setup_result.env_vars);
+    info!(
+        "Setting the following env vars {:?}",
+        enclave_setup_result.env_vars
+    );
     client_command.envs(enclave_setup_result.env_vars);
 
     let streams = connect_to_log_ports(log_conn_addrs).await?;
@@ -475,12 +549,17 @@ async fn start_user_program(
     let tasks = forward_client_logs(enable_log_forwarding, streams, &mut client_program).await?;
 
     info!("launching client program");
-    let output = client_program
-        .output()
-        .await
-        .map_err(|err| format!("Error while waiting for client program to finish: {:?}", err))?;
+    let output = client_program.output().await.map_err(|err| {
+        format!(
+            "Error while waiting for client program to finish: {:?}",
+            err
+        )
+    })?;
 
-    info!("client program returns result status >> {:?}", output.status);
+    info!(
+        "client program returns result status >> {:?}",
+        output.status
+    );
     let result = if let Some(code) = output.status.code() {
         UserProgramExitStatus::ExitCode(code)
     } else {
@@ -492,7 +571,9 @@ async fn start_user_program(
     Ok(result)
 }
 
-async fn setup_tap_devices(vsock: &mut AsyncVsockStream) -> Result<EnclaveNetworkingSetupResult, String> {
+async fn setup_tap_devices(
+    vsock: &mut AsyncVsockStream,
+) -> Result<EnclaveNetworkingSetupResult, String> {
     let mut result = setup_enclave_networking(vsock).await?;
     info!("Finished networking setup.");
 
@@ -508,7 +589,9 @@ async fn setup_tap_devices(vsock: &mut AsyncVsockStream) -> Result<EnclaveNetwor
     Ok(result)
 }
 
-async fn setup_file_system_tap_device(configuration: PrivateNetworkDeviceSettings) -> Result<TapDeviceInfo, String> {
+async fn setup_file_system_tap_device(
+    configuration: PrivateNetworkDeviceSettings,
+) -> Result<TapDeviceInfo, String> {
     let tap = create_async_tap_device(&tap_device_config(
         &configuration.l3_address,
         &configuration.name,
@@ -516,7 +599,10 @@ async fn setup_file_system_tap_device(configuration: PrivateNetworkDeviceSetting
     ))?;
     let fs_vsock = connect_to_parent_async(configuration.vsock_port_number).await?;
 
-    info!("FS Device {} is connected and ready.", configuration.vsock_port_number);
+    info!(
+        "FS Device {} is connected and ready.",
+        configuration.vsock_port_number
+    );
 
     Ok(TapDeviceInfo {
         vsock: fs_vsock,
@@ -547,7 +633,9 @@ struct EnclaveNetworkingSetupResult {
     tap_devices: Vec<TapDeviceInfo>,
 }
 
-async fn setup_enclave_networking(parent_port: &mut AsyncVsockStream) -> Result<EnclaveNetworkingSetupResult, String> {
+async fn setup_enclave_networking(
+    parent_port: &mut AsyncVsockStream,
+) -> Result<EnclaveNetworkingSetupResult, String> {
     let netlink = Netlink::new();
 
     let device_settings_list = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::NetworkDeviceSettings(s) => s)?;
@@ -556,10 +644,16 @@ async fn setup_enclave_networking(parent_port: &mut AsyncVsockStream) -> Result<
 
     for device_settings in &device_settings_list {
         let tap = setup_network_device(device_settings, &netlink).await?;
-        info!("Trying to connect on port {}", device_settings.vsock_port_number);
+        info!(
+            "Trying to connect on port {}",
+            device_settings.vsock_port_number
+        );
         let vsock = connect_to_parent_async(device_settings.vsock_port_number).await?;
 
-        info!("Device {} is connected and ready.", device_settings.vsock_port_number);
+        info!(
+            "Device {} is connected and ready.",
+            device_settings.vsock_port_number
+        );
 
         tap_devices.push(TapDeviceInfo {
             vsock,
@@ -570,7 +664,8 @@ async fn setup_enclave_networking(parent_port: &mut AsyncVsockStream) -> Result<
 
     let global_settings = extract_enum_value!(parent_port.read_lv().await?, SetupMessages::GlobalNetworkSettings(s) => s)?;
 
-    fs::create_dir("/run/resolvconf").map_err(|err| format!("Failed creating /run/resolvconf. {:?}", err))?;
+    fs::create_dir("/run/resolvconf")
+        .map_err(|err| format!("Failed creating /run/resolvconf. {:?}", err))?;
 
     for file in global_settings.global_settings_list {
         write_to_file(Path::new(&file.path), &file.data, &file.path)?;
@@ -587,11 +682,14 @@ async fn setup_enclave_networking(parent_port: &mut AsyncVsockStream) -> Result<
     })
 }
 
-async fn setup_network_device(parent_settings: &NetworkDeviceSettings, netlink: &Netlink) -> Result<AsyncDevice, String> {
+async fn setup_network_device(
+    parent_settings: &NetworkDeviceSettings,
+    netlink: &Netlink,
+) -> Result<AsyncDevice, String> {
     let tap_device = create_async_tap_device(&tun::Configuration::from(parent_settings))?;
 
-    let tap_index =
-        if_nametoindex(tap_device.get_ref().name()).map_err(|err| format!("Cannot find index for tap device {:?}", err))?;
+    let tap_index = if_nametoindex(tap_device.get_ref().name())
+        .map_err(|err| format!("Cannot find index for tap device {:?}", err))?;
 
     info!(
         "Setting up device with index {} and settings {:?}.",
@@ -628,7 +726,9 @@ async fn setup_network_device(parent_settings: &NetworkDeviceSettings, netlink: 
     // those entries from parent as it becomes the only way for the enclave to know
     // it's neighbours.
     for arp_entry in &parent_settings.static_arp_entries {
-        netlink.add_neighbour_for_device(tap_index, arp_entry).await?;
+        netlink
+            .add_neighbour_for_device(tap_index, arp_entry)
+            .await?;
 
         debug!("ARP entry {:?} is set.", arp_entry);
     }
@@ -636,7 +736,10 @@ async fn setup_network_device(parent_settings: &NetworkDeviceSettings, netlink: 
     Ok(tap_device)
 }
 
-pub(crate) async fn setup_enclave_certification<Socket: AsyncWrite + AsyncRead + Unpin + Send, Api: CSRApi>(
+pub(crate) async fn setup_enclave_certification<
+    Socket: AsyncWrite + AsyncRead + Unpin + Send,
+    Api: CSRApi,
+>(
     vsock: &mut Socket,
     csr_api: Api,
     app_config_id: &Option<String>,
@@ -664,7 +767,10 @@ pub(crate) async fn setup_enclave_certification<Socket: AsyncWrite + AsyncRead +
                 fs_root,
             ));
         } else {
-            return Err(format!("key param not specified for cert config {:?}", cert_config));
+            return Err(format!(
+                "key param not specified for cert config {:?}",
+                cert_config
+            ));
         }
     }
 
@@ -686,20 +792,35 @@ async fn connect_to_parent_async(port: u32) -> Result<AsyncVsockStream, String> 
 }
 
 fn read_enclave_manifest(path: &Path) -> Result<EnclaveManifest, String> {
-    let settings_raw = fs::read_to_string(path).map_err(|err| format!("Failed to read enclave manifest file. {:?}", err))?;
+    let settings_raw = fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read enclave manifest file. {:?}", err))?;
 
-    serde_json::from_str(&settings_raw).map_err(|err| format!("Failed to deserialize enclave manifest. {:?}", err))
+    serde_json::from_str(&settings_raw)
+        .map_err(|err| format!("Failed to deserialize enclave manifest. {:?}", err))
 }
 
-pub(crate) fn write_to_file<C: AsRef<[u8]> + ?Sized>(path: &Path, data: &C, entity_name: &str) -> Result<(), String> {
-    fs::write(path, data).map_err(|err| format!("Failed to write {} into file {}. {:?}", path.display(), entity_name, err))
+pub(crate) fn write_to_file<C: AsRef<[u8]> + ?Sized>(
+    path: &Path,
+    data: &C,
+    entity_name: &str,
+) -> Result<(), String> {
+    fs::write(path, data).map_err(|err| {
+        format!(
+            "Failed to write {} into file {}. {:?}",
+            path.display(),
+            entity_name,
+            err
+        )
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use api_model::enclave::{EnclaveManifest, FileSystemConfig, User, UserConfig, UserProgramConfig, WorkingDir};
+    use api_model::enclave::{
+        EnclaveManifest, FileSystemConfig, User, UserConfig, UserProgramConfig, WorkingDir,
+    };
     use async_trait::async_trait;
     use shared::models::NBDConfiguration;
     use shared::socket::InMemorySocket;
@@ -710,7 +831,11 @@ mod tests {
     struct MockFileSystemApi {}
     #[async_trait]
     impl<'a> FileSystemSetupApi<'a> for MockFileSystemApi {
-        async fn setup(&self, _nbd_config: NBDConfiguration, _arg: FileSystemSetupConfig<'a>) -> Result<usize, String> {
+        async fn setup(
+            &self,
+            _nbd_config: NBDConfiguration,
+            _arg: FileSystemSetupConfig<'a>,
+        ) -> Result<usize, String> {
             Ok(777)
         }
     }
@@ -744,7 +869,8 @@ mod tests {
             cert_list: None,
         };
 
-        crate::enclave::setup_file_system(&mut enclave_socket, MockFileSystemApi {}, setup_config).await
+        crate::enclave::setup_file_system(&mut enclave_socket, MockFileSystemApi {}, setup_config)
+            .await
     }
 
     #[test]

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -14,6 +14,7 @@ use api_model::converter::CertificateConfig;
 use api_model::enclave::EnclaveManifest;
 use async_process::{Child, Command};
 use async_trait::async_trait;
+use em_client::Sha256Hash;
 use futures::io::{BufReader, Lines};
 use futures::stream::FuturesUnordered;
 use futures::{AsyncBufReadExt, StreamExt};
@@ -38,7 +39,7 @@ use tokio::task::JoinHandle;
 use tokio_vsock::{VsockStream as AsyncVsockStream, VsockStream};
 use tun::{AsyncDevice, Device};
 
-use crate::app_configuration::{setup_application_configuration, EmAppApplicationConfiguration, EmAppCredentials, Sha256Hash};
+use crate::app_configuration::{setup_application_configuration, EmAppApplicationConfiguration, EmAppCredentials};
 use crate::certificate::{create_signer_key, default_certificate, request_certificate, write_certificate, CSRApi, CertificateResult, CertificateWithPath, EmAppCSRApi, DEFAULT_CERT_DIR, DEFAULT_CERT_RSA_KEY_SIZE};
 use crate::file_system::{
     close_dm_crypt_device, close_dm_verity_volume, copy_dns_file_to_mount, copy_startup_binary_to_mount,

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -19,7 +19,6 @@ use futures::stream::FuturesUnordered;
 use futures::{AsyncBufReadExt, StreamExt};
 use log::{debug, info, warn};
 use nix::net::if_::if_nametoindex;
-use sdkms::api_model::Blob;
 use shared::models::{
     ApplicationConfiguration, NBDConfiguration, NetworkDeviceSettings, PrivateNetworkDeviceSettings, SetupMessages,
     UserProgramExitStatus,
@@ -219,7 +218,7 @@ fn setup_app_configuration(
             &app_config.ccm_backend_url,
             api,
             Path::new(ENCLAVE_FS_OVERLAY_ROOT),
-            Blob::from(id.as_str()),
+            &id,
         )
     } else {
         Ok(())

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -222,7 +222,7 @@ fn setup_app_configuration(
             &app_config.ccm_backend_url,
             api,
             Path::new(ENCLAVE_FS_OVERLAY_ROOT),
-            app_config_id,
+            &app_config_id,
         )
     } else {
         Ok(())

--- a/vsock-proxy/enclave/src/file_system.rs
+++ b/vsock-proxy/enclave/src/file_system.rs
@@ -82,7 +82,7 @@ pub(crate) async fn mount_file_system_nodes(nodes: &[FileSystemNode], mount_opti
             FileSystemNode::TreeNode(node_path) => {
                 let formatted_mount_point_str = format!("{}{node_path}", ENCLAVE_FS_OVERLAY_ROOT, node_path = node_path);
                 let mut mount_args = vec!["--rbind", node_path, &formatted_mount_point_str];
-                if node_path.clone() == "/tmp" && mount_options.is_tmp_exec {
+                if *node_path == "/tmp" && mount_options.is_tmp_exec {
                     mount_args.push("-o");
                     mount_args.push("exec");
                     // Make the tmp directory of the enclave base image executable first

--- a/vsock-proxy/enclave/src/file_system.rs
+++ b/vsock-proxy/enclave/src/file_system.rs
@@ -19,9 +19,7 @@ use serde_json;
 use shared::{run_subprocess, run_subprocess_with_output_setup, CommandOutputConfig};
 
 use crate::certificate::{CertificateResult, DEFAULT_CERT_DIR};
-use crate::dsm_key_config::{
-    dsm_dec_with_overlayfs_key, dsm_enc_with_overlayfs_key, DEFAULT_DSM_ENDPOINT,
-};
+use crate::dsm_key_config::{dsm_dec_with_overlayfs_key, dsm_enc_with_overlayfs_key, DEFAULT_DSM_ENDPOINT};
 
 const ENCLAVE_FS_LOWER: &str = "/mnt/lower";
 const ENCLAVE_FS_RW_ROOT: &str = "/mnt/overlayfs";
@@ -75,27 +73,14 @@ pub(crate) enum FileSystemNode {
     File(&'static str),
 }
 
-pub(crate) async fn mount_file_system_nodes(
-    nodes: &[FileSystemNode],
-    mount_options: FsMountOptions,
-) -> Result<(), String> {
+pub(crate) async fn mount_file_system_nodes(nodes: &[FileSystemNode], mount_options: FsMountOptions) -> Result<(), String> {
     for node in nodes {
         match node {
             FileSystemNode::Proc => {
-                run_mount(&[
-                    "-t",
-                    "proc",
-                    "/proc",
-                    &format!("{}/proc/", ENCLAVE_FS_OVERLAY_ROOT),
-                ])
-                .await?;
+                run_mount(&["-t", "proc", "/proc", &format!("{}/proc/", ENCLAVE_FS_OVERLAY_ROOT)]).await?;
             }
             FileSystemNode::TreeNode(node_path) => {
-                let formatted_mount_point_str = format!(
-                    "{}{node_path}",
-                    ENCLAVE_FS_OVERLAY_ROOT,
-                    node_path = node_path
-                );
+                let formatted_mount_point_str = format!("{}{node_path}", ENCLAVE_FS_OVERLAY_ROOT, node_path = node_path);
                 let mut mount_args = vec!["--rbind", node_path, &formatted_mount_point_str];
                 if *node_path == "/tmp" && mount_options.is_tmp_exec {
                     mount_args.push("-o");
@@ -111,11 +96,7 @@ pub(crate) async fn mount_file_system_nodes(
                 run_mount(&[
                     "--bind",
                     file_path,
-                    &format!(
-                        "{}{file_path}",
-                        ENCLAVE_FS_OVERLAY_ROOT,
-                        file_path = file_path
-                    ),
+                    &format!("{}{file_path}", ENCLAVE_FS_OVERLAY_ROOT, file_path = file_path),
                 ])
                 .await?;
             }
@@ -147,8 +128,7 @@ pub(crate) fn generate_keyfile() -> Result<Vec<u8>, String> {
         .map_err(|err| format!("Unable to fill key buffer with random data : {:?}", err))?;
 
     // Write the key contents to the keyfile
-    let mut key_file = fs::File::create(CRYPT_KEYFILE)
-        .map_err(|err| format!("Unable to create key file : {:?}", err))?;
+    let mut key_file = fs::File::create(CRYPT_KEYFILE).map_err(|err| format!("Unable to create key file : {:?}", err))?;
     key_file
         .write(&*arr.clone())
         .map_err(|err| format!("Unable to write to key file: {:?}", err))?;
@@ -165,19 +145,11 @@ pub(crate) fn generate_keyfile() -> Result<Vec<u8>, String> {
 /// The minimum size of a luks2 header is 16MB - it is important that the size
 /// of the device meets this requirement (RW_BLOCK_FILE_DEFAULT_SIZE).
 async fn luks_format_device(key_path: &Path, device_path: &str) -> Result<(), String> {
-    let key_path_as_str = key_path.to_str().ok_or(format!(
-        "Failed converting path {} to string",
-        key_path.display()
-    ))?;
+    let key_path_as_str = key_path
+        .to_str()
+        .ok_or(format!("Failed converting path {} to string", key_path.display()))?;
 
-    let luks_format_args = [
-        "luksFormat",
-        "-q",
-        "--type",
-        "luks2",
-        device_path,
-        key_path_as_str,
-    ];
+    let luks_format_args = ["luksFormat", "-q", "--type", "luks2", device_path, key_path_as_str];
     run_subprocess("cryptsetup", &luks_format_args).await
 }
 
@@ -196,25 +168,10 @@ async fn is_luks_device(device_path: &str) -> Result<async_process::Output, Stri
 /// Export or import a token object from the given luks2 device. Always looks for the
 /// token with ID 0 and expects a file where the token is read from or written to.
 async fn update_luks_token(device_path: &str, token_path: &str, op: TokenOp) -> Result<(), String> {
-    let op_str = if op == TokenOp::Import {
-        "import"
-    } else {
-        "export"
-    };
+    let op_str = if op == TokenOp::Import { "import" } else { "export" };
 
-    info!(
-        "{:?} token for device {:?} at {:?}",
-        &op_str, &device_path, &token_path
-    );
-    let token_args = [
-        "token",
-        op_str,
-        "--token-id",
-        "0",
-        "--json-file",
-        token_path,
-        device_path,
-    ];
+    info!("{:?} token for device {:?} at {:?}", &op_str, &device_path, &token_path);
+    let token_args = ["token", op_str, "--token-id", "0", "--json-file", token_path, device_path];
     run_subprocess("cryptsetup", &token_args).await
 }
 
@@ -226,8 +183,7 @@ async fn get_key_from_out_token(
     cert_list: Option<&mut CertificateResult>,
 ) -> Result<(), String> {
     // Open and parse the dmcrypt volume token file
-    let mut token_file = fs::File::open(TOKEN_OUT_FILE)
-        .map_err(|err| format!("Unable to open token out file : {:?}", err))?;
+    let mut token_file = fs::File::open(TOKEN_OUT_FILE).map_err(|err| format!("Unable to open token out file : {:?}", err))?;
     let mut token_contents = [0; MAX_TOKEN_SIZE];
     let token_size = token_file
         .read(&mut token_contents)
@@ -235,14 +191,12 @@ async fn get_key_from_out_token(
 
     info!(
         "Token contents are >> {:?} : {:?}",
-        std::str::from_utf8(&token_contents.clone())
-            .map_err(|e| format!("Unable to convert token contents to utf8 : {:?}", e)),
+        std::str::from_utf8(&token_contents.clone()).map_err(|e| format!("Unable to convert token contents to utf8 : {:?}", e)),
         token_size
     );
 
-    let token_json_obj: LuksToken =
-        serde_json::from_slice(token_contents.split_at(token_size).0)
-            .map_err(|err| format!("Unable to decode Token json object from slice : {:?}", err))?;
+    let token_json_obj: LuksToken = serde_json::from_slice(token_contents.split_at(token_size).0)
+        .map_err(|err| format!("Unable to decode Token json object from slice : {:?}", err))?;
 
     // Fetch the decrypted volume passkey
     let dec_resp = dsm_dec_with_overlayfs_key(
@@ -254,8 +208,7 @@ async fn get_key_from_out_token(
     )?;
 
     // Create the key file
-    let key_file = fs::File::create(CRYPT_KEYFILE)
-        .map_err(|err| format!("Unable to create key file : {:?}", err));
+    let key_file = fs::File::create(CRYPT_KEYFILE).map_err(|err| format!("Unable to create key file : {:?}", err));
     let key_contents = dec_resp.plain;
 
     key_file?
@@ -321,11 +274,7 @@ async fn get_key_file(
 /// Generate the luks2 token object and write the same to
 /// the json file which will be used to add a luks2 header
 /// to the RW blockfile
-fn create_luks2_token_input(
-    token_path: &str,
-    env_vars: &[(String, String)],
-    enc_resp: EncryptResponse,
-) -> Result<(), String> {
+fn create_luks2_token_input(token_path: &str, env_vars: &[(String, String)], enc_resp: EncryptResponse) -> Result<(), String> {
     info!("Creating Luks2 token object");
     let iv = enc_resp
         .iv
@@ -338,20 +287,18 @@ fn create_luks2_token_input(
     let token_object = LuksToken {
         token_type: "Fortanix-sealing-key".to_string(),
         key_slots: vec!["0".to_string()],
-        endpoint: find_env_or_err("FS_DSM_ENDPOINT", env_vars)
-            .unwrap_or(DEFAULT_DSM_ENDPOINT.to_string()),
+        endpoint: find_env_or_err("FS_DSM_ENDPOINT", env_vars).unwrap_or(DEFAULT_DSM_ENDPOINT.to_string()),
         isvsvn: None,
         tag,
         enc_key: enc_resp.cipher,
         iv,
     };
 
-    let token_string = serde_json::to_string(&token_object)
-        .map_err(|err| format!("Unable to convert token object to string : {:?}", err))?;
+    let token_string =
+        serde_json::to_string(&token_object).map_err(|err| format!("Unable to convert token object to string : {:?}", err))?;
 
     info!("Writing luks2 token to file >> {:?}", token_string);
-    let mut token_file = File::create(token_path)
-        .map_err(|err| format!("Unable to create token input file : {:?}", err))?;
+    let mut token_file = File::create(token_path).map_err(|err| format!("Unable to create token input file : {:?}", err))?;
     token_file
         .write_all(&*token_string.into_bytes())
         .map_err(|err| format!("Unable to write to token object: {:?}", err))?;
@@ -365,12 +312,8 @@ pub(crate) async fn mount_read_write_file_system(
     enable_overlayfs_persistence: bool,
 ) -> Result<(), String> {
     // Create dir to get rid of the warning that is printed to the console by cryptsetup
-    fs::create_dir_all(DM_CRYPT_FOLDER).map_err(|err| {
-        format!(
-            "Failed to create folder {} for cryptsetup path. {:?}",
-            DM_CRYPT_FOLDER, err
-        )
-    })?;
+    fs::create_dir_all(DM_CRYPT_FOLDER)
+        .map_err(|err| format!("Failed to create folder {} for cryptsetup path. {:?}", DM_CRYPT_FOLDER, err))?;
 
     let create_ext4 = get_key_file(env_vars, cert_list, enable_overlayfs_persistence).await?;
 
@@ -426,38 +369,22 @@ pub(crate) async fn mount_overlay_fs() -> Result<(), String> {
         ENCLAVE_FS_LOWER, ENCLAVE_FS_UPPER, ENCLAVE_FS_WORK
     );
 
-    run_mount(&[
-        "-t",
-        "overlay",
-        "-o",
-        &overlay_dir_config,
-        "none",
-        ENCLAVE_FS_OVERLAY_ROOT,
-    ])
-    .await
+    run_mount(&["-t", "overlay", "-o", &overlay_dir_config, "none", ENCLAVE_FS_OVERLAY_ROOT]).await
 }
 
 pub(crate) fn create_overlay_dirs() -> Result<(), String> {
-    fs::create_dir(ENCLAVE_FS_LOWER)
-        .map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_LOWER, err))?;
-    fs::create_dir(ENCLAVE_FS_RW_ROOT)
-        .map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_UPPER, err))?;
-    fs::create_dir(ENCLAVE_FS_OVERLAY_ROOT).map_err(|err| {
-        format!(
-            "Failed to create dir {}. {:?}",
-            ENCLAVE_FS_OVERLAY_ROOT, err
-        )
-    })?;
+    fs::create_dir(ENCLAVE_FS_LOWER).map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_LOWER, err))?;
+    fs::create_dir(ENCLAVE_FS_RW_ROOT).map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_UPPER, err))?;
+    fs::create_dir(ENCLAVE_FS_OVERLAY_ROOT)
+        .map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_OVERLAY_ROOT, err))?;
 
     Ok(())
 }
 
 pub(crate) fn create_overlay_rw_dirs() -> Result<(), String> {
     info!("Creating work and upper layers....");
-    fs::create_dir(ENCLAVE_FS_WORK)
-        .map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_WORK, err))?;
-    fs::create_dir(ENCLAVE_FS_UPPER)
-        .map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_UPPER, err))?;
+    fs::create_dir(ENCLAVE_FS_WORK).map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_WORK, err))?;
+    fs::create_dir(ENCLAVE_FS_UPPER).map_err(|err| format!("Failed to create dir {}. {:?}", ENCLAVE_FS_UPPER, err))?;
 
     Ok(())
 }
@@ -497,17 +424,8 @@ pub(crate) async fn setup_dm_verity(config: &DMVerityConfig) -> Result<(), Strin
     run_subprocess("veritysetup", &args).await
 }
 
-pub(crate) async fn run_nbd_client(
-    server_address: IpAddr,
-    block_file_port: u16,
-    mount_name: &str,
-) -> Result<(), String> {
-    let args: [&str; 4] = [
-        &server_address.to_string(),
-        &block_file_port.to_string(),
-        "-N",
-        mount_name,
-    ];
+pub(crate) async fn run_nbd_client(server_address: IpAddr, block_file_port: u16, mount_name: &str) -> Result<(), String> {
+    let args: [&str; 4] = [&server_address.to_string(), &block_file_port.to_string(), "-N", mount_name];
     // NBD client exits with zero if it is able to connect to the server
     // and create /dev/nbdX device. After that we can `mount` said device
     // and use it to access the block file in `parent`.
@@ -520,21 +438,14 @@ pub(crate) fn copy_startup_binary_to_mount(startup_binary: &str) -> Result<(), S
     let from = STARTUP_PATH.to_string() + startup_binary;
     let to = ENCLAVE_FS_OVERLAY_ROOT.to_string() + startup_binary;
 
-    fs::copy(&from, &to).map_err(|err| {
-        format!(
-            "Failed to copy enclave startup binary from {} to {}. {:?}",
-            from, to, err
-        )
-    })?;
+    fs::copy(&from, &to).map_err(|err| format!("Failed to copy enclave startup binary from {} to {}. {:?}", from, to, err))?;
 
     Ok(())
 }
 
 pub(crate) fn create_fortanix_directories() -> Result<(), String> {
-    let dir = Path::new(ENCLAVE_FS_OVERLAY_ROOT)
-        .join(DEFAULT_CERT_DIR.strip_prefix("/").unwrap_or_default());
-    fs::create_dir_all(dir.clone())
-        .map_err(|e| format!("Failed to create fortanix directory {:?} : {:?}", dir, e))
+    let dir = Path::new(ENCLAVE_FS_OVERLAY_ROOT).join(DEFAULT_CERT_DIR.strip_prefix("/").unwrap_or_default());
+    fs::create_dir_all(dir.clone()).map_err(|e| format!("Failed to create fortanix directory {:?} : {:?}", dir, e))
 }
 
 pub(crate) fn copy_dns_file_to_mount() -> Result<(), String> {
@@ -544,15 +455,12 @@ pub(crate) fn copy_dns_file_to_mount() -> Result<(), String> {
 
     let nbd_etc_dir: &str = &format!("{}/etc", ENCLAVE_FS_OVERLAY_ROOT);
 
-    let nbd_run_resolv_file: &str =
-        &format!("{}/run/resolvconf/resolv.conf", ENCLAVE_FS_OVERLAY_ROOT);
+    let nbd_run_resolv_file: &str = &format!("{}/run/resolvconf/resolv.conf", ENCLAVE_FS_OVERLAY_ROOT);
 
     let nbd_etc_resolv_file: &str = &format!("{}/etc/resolv.conf", ENCLAVE_FS_OVERLAY_ROOT);
 
-    fs::create_dir_all(nbd_run_resolv_dir)
-        .map_err(|err| format!("Failed creating {} dir. {:?}", nbd_run_resolv_dir, err))?;
-    fs::create_dir_all(nbd_etc_dir)
-        .map_err(|err| format!("Failed creating {} dir. {:?}", nbd_etc_dir, err))?;
+    fs::create_dir_all(nbd_run_resolv_dir).map_err(|err| format!("Failed creating {} dir. {:?}", nbd_run_resolv_dir, err))?;
+    fs::create_dir_all(nbd_etc_dir).map_err(|err| format!("Failed creating {} dir. {:?}", nbd_etc_dir, err))?;
 
     // We copy resolv.conf from the enclave kernel into the block file mount point
     // so that DNS will work correctly after we do a `chroot`.
@@ -588,21 +496,12 @@ pub(crate) async fn unmount_file_system_nodes(nodes: &[FileSystemNode]) -> Resul
             FileSystemNode::TreeNode(node_path) => {
                 run_unmount(&[
                     "-R",
-                    &format!(
-                        "{}{node_path}",
-                        ENCLAVE_FS_OVERLAY_ROOT,
-                        node_path = node_path
-                    ),
+                    &format!("{}{node_path}", ENCLAVE_FS_OVERLAY_ROOT, node_path = node_path),
                 ])
                 .await?;
             }
             FileSystemNode::File(file_path) => {
-                run_unmount(&[&format!(
-                    "{}{file_path}",
-                    ENCLAVE_FS_OVERLAY_ROOT,
-                    file_path = file_path
-                )])
-                .await?;
+                run_unmount(&[&format!("{}{file_path}", ENCLAVE_FS_OVERLAY_ROOT, file_path = file_path)]).await?;
             }
         }
     }

--- a/vsock-proxy/parent/Cargo.toml
+++ b/vsock-proxy/parent/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/fortanix/salmiac"
 api-model = { path = "../../api-model" }
 async-process = "1.2.0"
 clap = "2.33"
-em-app = { git = "https://github.com/fortanix/rust-sgx.git" }
+em-app = { workspace = true }
 env_logger = "0.7"
 etherparse = { git = "https://github.com/fortanix/etherparse.git", branch = "udp_checksum_from_slice" }
 futures = "0.3"


### PR DESCRIPTION
This PR returns back functionality to check if the application configuration struct from CCM is indeed the one that we expect to see when starting a user application inside Salmiac. The verification process involves comparing the `SHA256` hash value of the `application configuration` structure with the `SHA256` hash value passed by the user through `ENCLAVEOS_APPCONFIG_ID` or `APPCONFIG_ID` env var when starting Salmiac itself.

This hash check prevents  malicious application configurations from being used when running a user application. Failure to pass the hash check results in no user application being run and Salmiac exiting with error code `-1`