### PR TITLE
Run build rust code CI only when PR is approved

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -15,10 +15,9 @@ on:
         required: true
       PAT:
         required: true
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+  on:
+    pull_request_review:
+      types: [ submitted, edited ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -27,7 +26,7 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
-
+    if: github.event_name == 'pull_request' && github.event.review.state == 'approved'
     steps:
       - name: Pull main repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This change changes CI behavior from running every time a new change is pushed into the branch to running only when PR is approved. This will decrease the number of CI runs as well as introduce a security guarantee that nobody can potentially extract CI secrets through malicious CI run by updating the PR with bogus data.