### PR TITLE
Turn off application tests CI

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -15,9 +15,10 @@ on:
         required: true
       PAT:
         required: true
-  on:
-    pull_request_review:
-      types: [ submitted, edited ]
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -26,7 +27,7 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
-    if: github.event_name == 'pull_request' && github.event.review.state == 'approved'
+
     steps:
       - name: Pull main repository
         uses: actions/checkout@v3
@@ -67,16 +68,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libpcap-dev amazon-ecr-credential-helper
 
-      - name: Install docker-credential-ecr-login
-        run: |
-          # Download the latest release of docker-credential-ecr-login
-          aws s3 cp s3://fortanix-internal-artifact-repository/other-packages/docker-credential-ecr-login .
-
-          # Make it executable
-          chmod +x docker-credential-ecr-login
-
-          # Move it to a directory in the PATH
-          sudo mv docker-credential-ecr-login /usr/local/bin/
+          # Setup docker-credential-ecr-login
+          sudo mv /usr/bin/docker-credential-ecr-login /usr/local/bin/
 
       - name: Build Rust code
         run: |
@@ -89,13 +82,13 @@ jobs:
         run: |
           ./unit-test-solution.sh
 
-      - name: Build application tests container
-        run: |
-          ./build-app-tests-container.sh
+#      - name: Build application tests container
+#        run: |
+#          ./build-app-tests-container.sh
 
-      - name: Run application tests container
-        env:
-          FORTANIX_API_KEY: ${{ secrets.FORTANIX_API_KEY }}
-          OVERLAYFS_UNIT_TEST_API_KEY: ${{ secrets.OVERLAYFS_UNIT_TEST_API_KEY }}
-        run: |
-          ./run-application-tests.sh ${{ env.TESTS_CONTAINER_ECR }} ${{ env.FORTANIX_API_KEY }}
+#      - name: Run application tests container
+#        env:
+#          FORTANIX_API_KEY: ${{ secrets.FORTANIX_API_KEY }}
+#          OVERLAYFS_UNIT_TEST_API_KEY: ${{ secrets.OVERLAYFS_UNIT_TEST_API_KEY }}
+#        run: |
+#         ./run-application-tests.sh ${{ env.TESTS_CONTAINER_ECR }} ${{ env.FORTANIX_API_KEY }}

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           ./unit-test-solution.sh
 
+#       Will be uncommented in RTE-188
 #      - name: Build application tests container
 #        run: |
 #          ./build-app-tests-container.sh

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -68,8 +68,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libpcap-dev amazon-ecr-credential-helper
 
-          # Setup docker-credential-ecr-login
-          sudo mv /usr/bin/docker-credential-ecr-login /usr/local/bin/
+      - name: Install docker-credential-ecr-login
+        run: |
+          # Download the latest release of docker-credential-ecr-login
+          aws s3 cp s3://fortanix-internal-artifact-repository/other-packages/docker-credential-ecr-login .
 
       - name: Build Rust code
         run: |

--- a/make/salmiac-tests-container.make
+++ b/make/salmiac-tests-container.make
@@ -127,4 +127,4 @@ $(TESTS-CONTAINER): $(TESTS-STAGE-CONTENTS)
 
 $(TESTS-CONTAINER-APP-TESTS-FILE)::    | $(dir $(TESTS-CONTAINER-APP-TESTS-FILE))
 
-$(eval $(call make-cp-rule,/usr/local/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))
+$(eval $(call make-cp-rule,/usr/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))


### PR DESCRIPTION
This PR turns off application tests CI until we move test images into a public repository. Additionally the PR contains the following small additions:
1) Reverted back policy to run CI only on successful review as it blocks the iterative process to test changes for CI itself. Now with application tests turned off there is no danger in anyone running a small package of `project build + unit tests`
2) `docker-credential-ecr-login` is now downloaded from a public place instead of a private one 