### PR TITLE
Change paths of private artifact dependencies to a public ones

### DIFF
--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -75,6 +75,9 @@ jobs:
           # Make it executable
           chmod +x docker-credential-ecr-login
 
+          # Move it to a directory in the PATH
+          sudo mv docker-credential-ecr-login /usr/local/bin/
+
       - name: Build Rust code
         run: |
           ./build-converter.sh

--- a/.github/workflows/build-solution.yml
+++ b/.github/workflows/build-solution.yml
@@ -75,9 +75,6 @@ jobs:
           # Make it executable
           chmod +x docker-credential-ecr-login
 
-          # Move it to a directory in the PATH
-          sudo mv docker-credential-ecr-login /usr/local/bin/
-
       - name: Build Rust code
         run: |
           ./build-converter.sh

--- a/build-app-tests-container.sh
+++ b/build-app-tests-container.sh
@@ -10,7 +10,7 @@ FLAVOR=debug
 if [ -z "$SKIP_RUNNING_TESTS" ]; then
   make tests-container FLAVOR=$FLAVOR
   TESTS_CONTAINER_TAG=$(cat build/nitro-$FLAVOR/tests-container-tag)
-  TESTS_CONTAINER_ECR="513076507034.dkr.ecr.us-west-1.amazonaws.com/development-images/$TESTS_CONTAINER_TAG"
+  TESTS_CONTAINER_ECR="513076507034.dkr.ecr.us-west-1.amazonaws.com/salmiac-github-ci/$TESTS_CONTAINER_TAG"
 
   docker load -i build/nitro-$FLAVOR/salmiac-tests-container.tar.gz
   docker tag $TESTS_CONTAINER_TAG $TESTS_CONTAINER_ECR

--- a/docker/build-enclave-kernel.sh
+++ b/docker/build-enclave-kernel.sh
@@ -7,7 +7,7 @@ set -exo pipefail
 ARTIFACT_NAME="amzn-linux-nbd-v1.tar"
 ARTIFACT_DIR="amzn-linux-nbd"
 fetchartifacts() {
-  aws s3 cp s3://fortanix-internal-artifact-repository/salmiac/$ARTIFACT_NAME .
+  aws s3 cp s3://downloads.fortanix.com/salmiac/$ARTIFACT_NAME .
   tar -xvf $ARTIFACT_NAME
 }
 

--- a/make/salmiac-tests-container.make
+++ b/make/salmiac-tests-container.make
@@ -127,4 +127,4 @@ $(TESTS-CONTAINER): $(TESTS-STAGE-CONTENTS)
 
 $(TESTS-CONTAINER-APP-TESTS-FILE)::    | $(dir $(TESTS-CONTAINER-APP-TESTS-FILE))
 
-$(eval $(call make-cp-rule,/usr/local/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))
+$(eval $(call make-cp-rule,/usr/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))

--- a/make/salmiac-tests-container.make
+++ b/make/salmiac-tests-container.make
@@ -127,4 +127,4 @@ $(TESTS-CONTAINER): $(TESTS-STAGE-CONTENTS)
 
 $(TESTS-CONTAINER-APP-TESTS-FILE)::    | $(dir $(TESTS-CONTAINER-APP-TESTS-FILE))
 
-$(eval $(call make-cp-rule,/usr/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))
+$(eval $(call make-cp-rule,/usr/local/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))

--- a/make/salmiac-tests-container.make
+++ b/make/salmiac-tests-container.make
@@ -93,7 +93,7 @@ $(eval $(call make-cp-rule,$(REPO_ROOT)/tools/app-test-inrfa/bin/tests-container
 $(eval $(call make-cp-rule,$(REPO_ROOT)/tools/app-test-infra/bin/tests-container-run.py,$(TESTS-STAGE-DIR)/tests-container-run.py))
 $(eval $(call make-cp-rule,$(REPO_ROOT)/test/tests-container-salmiac/docker-config.json,$(TESTS-STAGE-DIR)/docker-config.json))
 $(eval $(call make-cp-rule,$(REPO_ROOT)/tools/container-converter/target/$(FLAVOR)/container-converter,$(TESTS-STAGE-DIR)/container-converter))
-$(eval $(call pull-s3,s3\://fortanix-internal-artifact-repository/salmiac/$(ENCLAVE-KERNEL-TAR),$(TESTS-STAGE-DIR)/$(ENCLAVE-KERNEL-TAR)))
+$(eval $(call pull-s3,s3\://downloads.fortanix.com/salmiac/$(ENCLAVE-KERNEL-TAR),$(TESTS-STAGE-DIR)/$(ENCLAVE-KERNEL-TAR)))
 $(eval $(call untar-pkg,$(TESTS-STAGE-DIR)/$(ENCLAVE-KERNEL-TAR),$(TESTS-STAGE-DIR)/amzn-linux-nbd))
 
 # This generates the rules for copying the contents of tools/app-test-infra/python

--- a/run-application-tests.sh
+++ b/run-application-tests.sh
@@ -15,10 +15,10 @@ echo "AWS_CREDENTIALS=$(/usr/bin/base64 --wrap=0 < ~/.aws/credentials)" >> docke
 ECR_PASSWORD=$(aws ecr get-login-password --region us-west-1)
 echo "ECR_PASSWORD=$ECR_PASSWORD" >> docker-env
 
-PARENT_IMAGE=513076507034.dkr.ecr.us-west-1.amazonaws.com/nitro-parent-base:1.1.1
+PARENT_IMAGE=fortanix/nitro-parent-base:1.1.4
 echo "PARENT_IMAGE=$PARENT_IMAGE" >> docker-env
 
-ENCLAVE_IMAGE=513076507034.dkr.ecr.us-west-1.amazonaws.com/nitro-enclave-base:1.0.1
+ENCLAVE_IMAGE=fortanix/nitro-enclave-base:1.0.2
 echo "ENCLAVE_IMAGE=$ENCLAVE_IMAGE" >> docker-env
 
 echo "FORTANIX_API_KEY=$FORTANIX_API_KEY" >> docker-env

--- a/test/tests-container-salmiac/Dockerfile-salmiac-ub20
+++ b/test/tests-container-salmiac/Dockerfile-salmiac-ub20
@@ -1,4 +1,4 @@
-FROM 513076507034.dkr.ecr.us-west-1.amazonaws.com/development-images/nitro-parent-base:1.1.4 as nitro-cli
+FROM fortanix/nitro-parent-base:1.1.4 as nitro-cli
 
 ARG PLATFORM
 ARG FLAVOR


### PR DESCRIPTION
 Changes the ECR buffer used to transfer application tests container into a Nitro-capable EC2 instance to a new path. Also changes `enclave-base` `parent-base`  and `amazon-linux-nbd` from internal repo to a public one.