### PR TITLE
Adapt legacy code to new version of application tests infrastructure

### DIFF
--- a/make/salmiac-tests-container.make
+++ b/make/salmiac-tests-container.make
@@ -127,4 +127,4 @@ $(TESTS-CONTAINER): $(TESTS-STAGE-CONTENTS)
 
 $(TESTS-CONTAINER-APP-TESTS-FILE)::    | $(dir $(TESTS-CONTAINER-APP-TESTS-FILE))
 
-$(eval $(call make-cp-rule,/usr/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))
+$(eval $(call make-cp-rule,/usr/local/bin/$(DOCKER-AWS-HELPER),$(TESTS-STAGE-DIR)/$(DOCKER-AWS-HELPER)))

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -73,7 +73,7 @@ const PARENT_IMAGE: &str = "parent-base";
 
 const ENCLAVE_IMAGE: &str = "enclave-base";
 
-const ENCLAVE_IMAGE_DEBUG: &str = "enclave-base-debug";
+const ENCLAVE_IMAGE_DEBUG: &str = "enclave-base";
 
 const DEFAULT_RSA_SIZE: u32 = 3072;
 const RSA_KEY_SIZES: [u32; 3] = [ 2048, DEFAULT_RSA_SIZE, 4096 ];
@@ -203,11 +203,12 @@ async fn run0(
 
         let enclave_base_image = get_enclave_base_image(&enclave_base_image_str).await?;
 
-        let user_program_config = if conversion_request.is_debug() {
+        let user_program_config = create_user_program_config(&conversion_request.request.converter_options, &input_image.image)?;
+        /*let user_program_config = if conversion_request.is_debug() {
             enclave_base_image.create_user_program_config()?
         } else {
             create_user_program_config(&conversion_request.request.converter_options, &input_image.image)?
-        };
+        };*/
 
         debug!("User program config is: {:?}", user_program_config);
 

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -73,8 +73,6 @@ const PARENT_IMAGE: &str = "parent-base";
 
 const ENCLAVE_IMAGE: &str = "enclave-base";
 
-const ENCLAVE_IMAGE_DEBUG: &str = "enclave-base";
-
 const DEFAULT_RSA_SIZE: u32 = 3072;
 const RSA_KEY_SIZES: [u32; 3] = [ 2048, DEFAULT_RSA_SIZE, 4096 ];
 
@@ -194,21 +192,12 @@ async fn run0(
 
     info!("Building enclave image!");
     let nitro_image_result = {
-        let enclave_base_image_str = if conversion_request.is_debug() {
-            env::var("ENCLAVE_IMAGE_DEBUG").unwrap_or(ENCLAVE_IMAGE_DEBUG.to_string())
-        } else {
-            env::var("ENCLAVE_IMAGE").unwrap_or(ENCLAVE_IMAGE.to_string())
-        };
+        let enclave_base_image_str = env::var("ENCLAVE_IMAGE").unwrap_or(ENCLAVE_IMAGE.to_string());
         info!("Enclave base image is {}", enclave_base_image_str);
 
         let enclave_base_image = get_enclave_base_image(&enclave_base_image_str).await?;
 
         let user_program_config = create_user_program_config(&conversion_request.request.converter_options, &input_image.image)?;
-        /*let user_program_config = if conversion_request.is_debug() {
-            enclave_base_image.create_user_program_config()?
-        } else {
-            create_user_program_config(&conversion_request.request.converter_options, &input_image.image)?
-        };*/
 
         debug!("User program config is: {:?}", user_program_config);
 

--- a/tools/container-converter/src/main.rs
+++ b/tools/container-converter/src/main.rs
@@ -30,7 +30,10 @@ async fn main() -> Result<(), String> {
 
     match container_converter::run(request).await {
         Ok(response) => {
-            println!("{:?}", response);
+            let response_serialized = serde_json::to_string(&response)
+                .map_err(|err| format!("Failed serializing conversion request. {:?}", err))?;
+
+            println!("Successful nitro conversion: {:?}", response_serialized);
             Ok(())
         }
         Err(err) => {


### PR DESCRIPTION
This PR alters the legacy behavior of `container-converter` to fit with the new version of `app-test-infra` (https://github.com/fortanix/app-test-infra) when running application tests. In summary the following was done:

1) Container converter now prints `json serialized` conversion response into the stdout. Previously the response was serialized as a simple string and it would break the code in: https://github.com/fortanix/app-test-infra/blob/5abda4112fb64559eb4e0064cf78dc7e4a29cb0a/python/test_app.py#L1005C1-L1008C1
2) Container converter now prints a special key phrase when printing the response to stdout. This phrase is used to find the response by app-test infra code in: https://github.com/fortanix/app-test-infra/blob/5abda4112fb64559eb4e0064cf78dc7e4a29cb0a/python/test_app.py#L1383
3) The unfinished legacy debug image logic is completely removed from container converter. Previously it was part of the idea for converter to create a special image with debug tooling and a distinct suffix when `debug` flag is set to true. This was never realized into a full feature and now breaks the application tests infrastructure code because images with debug prefixes are not supported there. As this feature was never properly implemented and was never needed that much I believe it's best to remove it entirely.
4) Changed path of `DOCKER-AWS-HELPER` to be consistent with tool installation path on the executor machine.