### PR TITLE
Build fix

### DIFF
--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
  "serde_json 1.0.2",
  "shiplift",
  "sys-mount",
- "tar 0.4.43 (git+https://github.com/alexcrichton/tar-rs)",
+ "tar",
  "tempfile",
  "tokio",
  "toml",
@@ -1415,7 +1415,7 @@ dependencies = [
  "pin-project 1.0.10",
  "serde",
  "serde_json 1.0.81",
- "tar 0.4.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar",
  "tokio",
  "url",
 ]
@@ -1524,17 +1524,6 @@ dependencies = [
  "smart-default",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]

--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
  "serde_json 1.0.2",
  "shiplift",
  "sys-mount",
- "tar",
+ "tar 0.4.43 (git+https://github.com/alexcrichton/tar-rs)",
  "tempfile",
  "tokio",
  "toml",
@@ -1415,7 +1415,7 @@ dependencies = [
  "pin-project 1.0.10",
  "serde",
  "serde_json 1.0.81",
- "tar",
+ "tar 0.4.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "url",
 ]
@@ -1524,6 +1524,17 @@ dependencies = [
  "smart-default",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/tools/container-converter/Cargo.lock
+++ b/tools/container-converter/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
  "serde_json 1.0.2",
  "shiplift",
  "sys-mount",
- "tar",
+ "tar 0.4.43 (git+https://github.com/alexcrichton/tar-rs)",
  "tempfile",
  "tokio",
  "toml",
@@ -1415,7 +1415,7 @@ dependencies = [
  "pin-project 1.0.10",
  "serde",
  "serde_json 1.0.81",
- "tar",
+ "tar 0.4.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "url",
 ]
@@ -1531,6 +1531,16 @@ name = "tar"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.43"
+source = "git+https://github.com/alexcrichton/tar-rs#b6c50246286a17623d1be828137e20fdc2b09e2e"
 dependencies = [
  "filetime",
  "libc",

--- a/tools/container-converter/Cargo.toml
+++ b/tools/container-converter/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_json =  { git = "https://github.com/fortanix/serde-json.git", branch = "base64_bytes" }
 shiplift = { git = "https://github.com/fortanix/shiplift.git" }
 sys-mount = "3"
-tar = "0.4.39"
+tar = { git = "https://github.com/alexcrichton/tar-rs" }
 tempfile = "3.2.0"
 tokio = { version = "1.0.1", features = ["macros", "rt"] }
 toml = "0.5.8"
@@ -35,5 +35,3 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 chrono = "0.4.22"
 
-[patch.crates-io]
-tar = { git = "https://github.com/alexcrichton/tar-rs" }

--- a/tools/container-converter/Cargo.toml
+++ b/tools/container-converter/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_json =  { git = "https://github.com/fortanix/serde-json.git", branch = "base64_bytes" }
 shiplift = { git = "https://github.com/fortanix/shiplift.git" }
 sys-mount = "3"
-tar = "0.4.39"
+tar = { git = "https://github.com/alexcrichton/tar-rs" }
 tempfile = "3.2.0"
 tokio = { version = "1.0.1", features = ["macros", "rt"] }
 toml = "0.5.8"

--- a/tools/container-converter/Cargo.toml
+++ b/tools/container-converter/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_json =  { git = "https://github.com/fortanix/serde-json.git", branch = "base64_bytes" }
 shiplift = { git = "https://github.com/fortanix/shiplift.git" }
 sys-mount = "3"
-tar = { git = "https://github.com/alexcrichton/tar-rs" }
+tar = "0.4.39"
 tempfile = "3.2.0"
 tokio = { version = "1.0.1", features = ["macros", "rt"] }
 toml = "0.5.8"
@@ -34,3 +34,6 @@ lazy_static = "1.4.0"
 
 [dev-dependencies]
 chrono = "0.4.22"
+
+[patch.crates-io]
+tar = { git = "https://github.com/alexcrichton/tar-rs" }

--- a/tools/container-converter/rust-toolchain.toml
+++ b/tools/container-converter/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "dev-2024-11-21-x86_64-unknown-linux-gnu"

--- a/tools/container-converter/rust-toolchain.toml
+++ b/tools/container-converter/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "dev-2024-11-21-x86_64-unknown-linux-gnu"

--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -275,7 +275,7 @@ impl DockerUtil for DockerDaemon {
         let mut build_params = BuildParams::default();
         build_params.tag(image.to_string());
 
-        env::set_var("DOCKER_BUILDKIT", "1");
+        //env::set_var("DOCKER_BUILDKIT", "1");
 
         info!("Started building image {}", image.to_string());
 

--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::{env, fs};
+use std::{fs};
 
 use api_model::converter::AuthConfig;
 use async_trait::async_trait;
@@ -274,8 +274,6 @@ impl DockerUtil for DockerDaemon {
 
         let mut build_params = BuildParams::default();
         build_params.tag(image.to_string());
-
-        //env::set_var("DOCKER_BUILDKIT", "1");
 
         info!("Started building image {}", image.to_string());
 

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -894,11 +894,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2659,6 +2659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes build failure on the older versions of the compiler by downgrading the `home` crate and pinning the toolchain version.