### PR TITLE
Disable buildkit while building docker images

### DIFF
--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -275,7 +275,9 @@ impl DockerUtil for DockerDaemon {
         let mut build_params = BuildParams::default();
         build_params.tag(image.to_string());
 
-        env::set_var("DOCKER_BUILDKIT", "1");
+        // Disable buildkit as it makes converted images hang on CI machine with a docker version 20.10.25.
+        // The issue was found while working on RTE-324.
+        //env::set_var("DOCKER_BUILDKIT", "1");
 
         info!("Started building image {}", image.to_string());
 


### PR DESCRIPTION
Disables buildkit to fix the hang on CI machine that uses an older version of docker 20.10.25
