### PR TITLE
[PLAT-4201] remove "See more keys..." line from toml files

### DIFF
--- a/api-model/Cargo.toml
+++ b/api-model/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/enclave-startup/Cargo.toml
+++ b/enclave-startup/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 env_logger = "0.7"

--- a/tools/container-converter/Cargo.toml
+++ b/tools/container-converter/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 api-model = { path = "../../api-model", features = ["serde"] }

--- a/vsock-proxy/enclave/Cargo.toml
+++ b/vsock-proxy/enclave/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Fortanix, Inc."]
 edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 api-model = { path = "../../api-model", features = ["serde"] }

--- a/vsock-proxy/parent/Cargo.toml
+++ b/vsock-proxy/parent/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 api-model = { path = "../../api-model" }

--- a/vsock-proxy/parent/lib/Cargo.toml
+++ b/vsock-proxy/parent/lib/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 name = "parent_lib"

--- a/vsock-proxy/shared/Cargo.toml
+++ b/vsock-proxy/shared/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MPL-2.0"
 repository = "https://github.com/fortanix/salmiac"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-process = "1.2.0"


### PR DESCRIPTION
Small PR to throw out a spurious line in some `Cargo.toml` files, in line with some changes the platform team recently made in the roche repo