### PR TITLE
[RTE-500] Accessing node agent over tcp

### DIFF
--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -835,7 +835,13 @@ pub(crate) async fn setup_enclave_certification<Socket: AsyncWrite + AsyncRead +
                 debug!("node agent = {:?}", node_agent);
                 em_request_issue_certificate(node_agent.unwrap_or("localhost".into()), csr).await
             }
-            Some(vsock) => request_certificate(vsock, csr).await,
+            Some(vsock) => {
+                //request_certificate(vsock, csr).await,
+                debug!("request_issue_certificate...");
+                debug!("csr = {}", csr);
+                debug!("node agent = {:?}", node_agent);
+                em_request_issue_certificate(node_agent.unwrap_or("http://10.199.0.222:9092/v1".into()), csr).await
+            }
         }?;
 
         Ok(CertificateWithPath::new(

--- a/vsock-proxy/parent/lib/lib.rs
+++ b/vsock-proxy/parent/lib/lib.rs
@@ -36,7 +36,7 @@ pub struct NBDExportConfig {
     pub is_read_only: bool,
 }
 
-fn node_agent_address() -> Option<String> {
+pub fn node_agent_address() -> Option<String> {
     env::vars().find_map(|(k, v)| if k == "NODE_AGENT" {
         if !v.starts_with("http://") {
             Some("http://".to_string() + &v)

--- a/vsock-proxy/parent/lib/lib.rs
+++ b/vsock-proxy/parent/lib/lib.rs
@@ -60,6 +60,7 @@ pub async fn handle_csr_message<Socket: AsyncWrite + AsyncRead + Unpin + Send, C
     let request = tokio::time::timeout(
         CSR_REQUEST_TIMEOUT,
         task::spawn_blocking(move || -> Result<String, String> {
+            info!("Requesting CCM for App Certificate...");
             cert_api.request_issue_certificate(&address, csr)
         }))
             .await

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -104,6 +104,7 @@ pub(crate) async fn run(args: ParentConsoleArguments) -> Result<UserProgramExitS
     });
 
     send_env_variables(&mut enclave_port).await?;
+    send_node_agent_address(&mut enclave_port).await?;
     send_enclave_extra_console_args(&mut enclave_port, args.enclave_extra_args).await?;
 
     let setup_result = setup_parent(&mut enclave_port, args.rw_block_file_size.to_inner()).await?;
@@ -252,6 +253,12 @@ async fn send_env_variables(enclave_port: &mut AsyncVsockStream) -> Result<(), S
     let filtered_env_vars = filter_env_variables(Path::new(INSTALLATION_DIR).join(ORIG_ENV_LIST_PATH))?;
     info!("Passing these variables to the enclave : {:?}", filtered_env_vars);
     enclave_port.write_lv(&SetupMessages::EnvVariables(filtered_env_vars)).await
+}
+
+async fn send_node_agent_address(enclave_port: &mut AsyncVsockStream) -> Result<(), String> {
+    let address = parent_lib::node_agent_address();
+    info!("Returning node agent: {:?}", address);
+    enclave_port.write_lv(&SetupMessages::NodeAgentUrl(address)).await
 }
 
 async fn send_enclave_extra_console_args(enclave_port: &mut AsyncVsockStream, arguments: Vec<String>) -> Result<(), String> {

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -14,7 +14,7 @@ use std::{env, fs};
 use async_process::Command;
 use futures::stream::futures_unordered::FuturesUnordered;
 use ipnetwork::IpNetwork;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use parent_lib::{communicate_certificates, setup_file_system, CertificateApi, NBDExportConfig, NBD_EXPORTS};
 use shared::models::{
     ApplicationConfiguration, FileWithPath, GlobalNetworkSettings, SetupMessages, UserProgramExitStatus,

--- a/vsock-proxy/shared/src/models.rs
+++ b/vsock-proxy/shared/src/models.rs
@@ -29,6 +29,7 @@ pub enum SetupMessages {
     ExitEnclave,
     EncryptedSpaceAvailable(usize),
     AppLogPort(Vec<AppLogPortInfo>),
+    NodeAgentUrl(Option<String>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
PR #44 added a feature where app certs are renewed automatically. It relied on connecting to the parent (vsock connection) to eventually reach the node agent (tcp connection). Unfortunately that doesn't work as the parent shouldn't make outbound tcp connections; when packets return the connection is closed by the enclave as it doesn't know about the connection.
This PR fixes this by connecting to the node agent directly from the enclave VM (i.e., a tcp connection to the host). For this to work a new `SetupMessage` is created to pass the url the node agent needs to be accessed.
Currently the initial certificates are still requested by accessing the parent container. This code will be cleaned up in a subsequent PR.