### PR TITLE
[RTE-534] Disable mariadb app test

### DIFF
--- a/make/subdirs.make
+++ b/make/subdirs.make
@@ -2,7 +2,8 @@
 SUBDIRS = \
 	tools/app-test-infra/apps/bash \
 	tools/app-test-infra/apps/invalid-auth-config \
-	tools/app-test-infra/apps/mariadb \
+	# RTE-534 Disable until the test is made more stable
+	#tools/app-test-infra/apps/mariadb \
 	tools/app-test-infra/apps/nginx/self-proxy \
 	tools/app-test-infra/apps/python-default-appcert \
 	tools/app-test-infra/apps/python-minver \


### PR DESCRIPTION
The mariadb app test is flaky and leads to failures in CI jobs quiet often. Until the team investigates and makes the test more stable, disable it.