### PR TITLE
[RTE-910] Add script to convert a container image to a CPIO archive

### DIFF
--- a/docker/enclave-base/container_image_to_cpio.sh
+++ b/docker/enclave-base/container_image_to_cpio.sh
@@ -8,14 +8,13 @@ function show_usage() {
         [-h]                Show help
         [-k]                Keep intermediary files (default: false)
         [-o output_file]    CPIO output file (default: stdout)
-        -i <oci_url>        Image URL supported by skopeo copy (containers-storage, dir, docker, docker-archive, docker-daemon, oci, oci-archive, ostree, sif, tarball)
-        -t <image_tag>      Image tag"
+        -i <oci_url>        Image URL supported by skopeo copy (containers-storage, dir, docker, docker-archive, docker-daemon, oci, oci-archive, ostree, sif, tarball)"
 }
 
 keep_files=0
 output_file=/dev/stdout
-tag=latest
-while getopts "hi:ko:t:" option; do
+tag=salmiac
+while getopts "hi:ko:" option; do
     case $option in
         h)
             echo "Convert a container image to a CPIO New ASCII format"
@@ -31,9 +30,6 @@ while getopts "hi:ko:t:" option; do
         o)
             output_file=$(realpath "$OPTARG")
             ;;
-        t)
-            tag="$OPTARG"
-            ;;
         *)
             show_usage
             exit 1
@@ -47,14 +43,14 @@ if [ -z "${oci_url}" ]; then
 fi
 
 # Create temporary directory to extract image layers
-skopeo_tmp_dir=$(mktemp --directory --tmpdir="${PWD}")
+skopeo_tmp_dir="$(mktemp --directory --tmpdir="${PWD}")"
 
 # Copy image filesystem layers
-echo skopeo copy "${oci_url}:${tag}" "oci:${skopeo_tmp_dir}:${tag}" >&2
-skopeo copy "${oci_url}:${tag}" "oci:${skopeo_tmp_dir}:${tag}" >&2
+echo skopeo copy "${oci_url}" "oci:${skopeo_tmp_dir}:${tag}" >&2
+skopeo copy "${oci_url}" "oci:${skopeo_tmp_dir}:${tag}" >&2
 
 # Create temporary directory to unpack rootfs
-umoci_tmp_dir=$(mktemp --directory --tmpdir="${PWD}")
+umoci_tmp_dir="$(mktemp --directory --tmpdir="${PWD}")"
 
 # Extract image into a bundle
 echo umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}" >&2

--- a/docker/enclave-base/container_image_to_cpio.sh
+++ b/docker/enclave-base/container_image_to_cpio.sh
@@ -42,23 +42,22 @@ if [ -z "${oci_url}" ]; then
     exit 1
 fi
 
+set -x
 # Create temporary directory to extract image layers
 skopeo_tmp_dir="$(mktemp --directory --tmpdir="${PWD}")"
 
 # Copy image filesystem layers
-echo skopeo copy "${oci_url}" "oci:${skopeo_tmp_dir}:${tag}" >&2
 skopeo copy "${oci_url}" "oci:${skopeo_tmp_dir}:${tag}" >&2
 
 # Create temporary directory to unpack rootfs
 umoci_tmp_dir="$(mktemp --directory --tmpdir="${PWD}")"
 
 # Extract image into a bundle
-echo umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}" >&2
-umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}"
+umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}" >&2
 
 pushd "${umoci_tmp_dir}/rootfs" >&2
 find . | cpio --create --format newc --owner 0:0 > "${output_file}"
-popd > /dev/null >&2
+popd >&2
 
 if [ $keep_files == 0 ]; then
     rm -fr ${skopeo_tmp_dir} >&2

--- a/docker/enclave-base/container_image_to_cpio.sh
+++ b/docker/enclave-base/container_image_to_cpio.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Extracts filesystem layers using `skopeo`, extracts the filesystem using `umoci` and builds the CPIO archive using `cpio`.
+
+function show_usage() {
+    echo "Usage: $0 [OPTION...]
+        [-h]                Show help
+        [-k]                Keep intermediary files (default: false)
+        [-o output_file]    CPIO output file (default: stdout)
+        -i <oci_url>        Image URL supported by skopeo copy (containers-storage, dir, docker, docker-archive, docker-daemon, oci, oci-archive, ostree, sif, tarball)
+        -t <image_tag>      Image tag"
+}
+
+keep_files=0
+output_file=/dev/stdout
+tag=latest
+while getopts "hi:ko:t:" option; do
+    case $option in
+        h)
+            echo "Convert a container image to a CPIO New ASCII format"
+            show_usage
+            exit 0
+            ;;
+        i)
+            oci_url="$OPTARG"
+            ;;
+        k)
+            keep_files=1
+            ;;
+        o)
+            output_file=$(realpath "$OPTARG")
+            ;;
+        t)
+            tag="$OPTARG"
+            ;;
+        *)
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${oci_url}" ]; then
+    show_usage
+    exit 1
+fi
+
+# Create temporary directory to extract image layers
+skopeo_tmp_dir=$(mktemp --directory --tmpdir="${PWD}")
+
+# Copy image filesystem layers
+echo skopeo copy "${oci_url}:${tag}" "oci:${skopeo_tmp_dir}:${tag}" >&2
+skopeo copy "${oci_url}:${tag}" "oci:${skopeo_tmp_dir}:${tag}" >&2
+
+# Create temporary directory to unpack rootfs
+umoci_tmp_dir=$(mktemp --directory --tmpdir="${PWD}")
+
+# Extract image into a bundle
+echo umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}" >&2
+umoci unpack --rootless --image "${skopeo_tmp_dir}:${tag}" "${umoci_tmp_dir}"
+
+pushd "${umoci_tmp_dir}/rootfs" >&2
+find . | cpio --create --format newc --owner 0:0 > "${output_file}"
+popd > /dev/null >&2
+
+if [ $keep_files == 0 ]; then
+    rm -fr ${skopeo_tmp_dir} >&2
+    rm -fr ${umoci_tmp_dir} >&2
+fi


### PR DESCRIPTION
🔧 Uses [skopeo](https://github.com/containers/skopeo) and [umoci](https://umo.ci/) to extract the container image filesystem.

📦 Uses `cpio` to create the CPIO archive in New ASCII format.

🧪 Tested using a container image containing a basic init script which mounted a rootfs based on nginx image and handed over to `init.c`, using a generic Ubuntu kernel on QEMU.