### PR TITLE
Rte 916/sev snp measure

### DIFF
--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -12,6 +12,16 @@ RUN apt-get download ovmf && \
     dpkg -x ovmf*.deb ovmf_dir && \
     cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
 
+FROM debian:bookworm-slim AS sev_snp_measurement
+RUN apt-get update && apt-get install -y \
+        python3 \
+        python3-pip \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY staging/sev-snp-measure/requirements.txt /tmp/requirements.txt
+RUN pip install --break-system-packages --target /opt/sev-snp-dist -r /tmp/requirements.txt
+
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -19,13 +29,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         cryptsetup-bin \
-        python3 \
-        python3-pip \
-        git
+        python3
+
+COPY --from=sev_snp_measurement /opt/sev-snp-dist /opt/sev-snp-dist
+ENV PYTHONPATH="/opt/sev-snp-dist"
 
 COPY staging/sev-snp-measure /opt/sev-snp-measure
-RUN pip install --break-system-packages -r /opt/sev-snp-measure/requirements.txt && \
-    chmod +x /opt/sev-snp-measure/measure.py
+RUN chmod +x /opt/sev-snp-measure/measure.py
 
 RUN mkdir -p /var/log/enclave-os
 

--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -5,20 +5,27 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN mkdir -p /blob
 
 RUN apt-get download systemd-boot-efi && \
-dpkg -x systemd-boot-efi*.deb system_boot_efi_dir &&\
-cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
-
+    dpkg -x systemd-boot-efi*.deb system_boot_efi_dir && \
+    cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
 
 RUN apt-get download ovmf && \
-dpkg -x ovmf*.deb ovmf_dir && \
-cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
+    dpkg -x ovmf*.deb ovmf_dir && \
+    cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
 
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y cryptsetup-bin
+    apt-get install -y \
+        cryptsetup-bin \
+        python3 \
+        python3-pip \
+        git
+
+COPY staging/sev-snp-measure /opt/sev-snp-measure
+RUN pip install --break-system-packages -r /opt/sev-snp-measure/requirements.txt && \
+    chmod +x /opt/sev-snp-measure/measure.py
 
 RUN mkdir -p /var/log/enclave-os
 

--- a/docker/snp/build-conv-container.sh
+++ b/docker/snp/build-conv-container.sh
@@ -14,6 +14,9 @@ docker save -o ./staging/enclave-base.tar enclave-base
 docker save -o ./staging/enclave-base-gpu.tar enclave-base-snp-gpu
 docker save -o ./staging/parent-base.tar parent-base-snp
 
+# Stage sev-snp-measure tooling for the converter image
+cp -r ../../tools/sev-snp-measure ./staging/sev-snp-measure
+
 # Build the converter
 docker build -t snp-converter .
 

--- a/tools/container-converter/src/image_builder/enclave/mod.rs
+++ b/tools/container-converter/src/image_builder/enclave/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use self::nitro::EnclaveImageBuilder as PlatformEnclaveImageBuilder;
 pub(crate) mod snp;
 #[cfg(platform = "snp")]
 pub(crate) use self::snp::EnclaveImageBuilder as PlatformEnclaveImageBuilder;
+#[cfg(platform = "snp")]
+pub(crate) mod snp_measurement;
 
 use std::ffi::OsStr;
 use std::fmt::Debug;

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -114,11 +114,7 @@ fn create_initramfs(
     enclave_settings: &EnclaveSettings,
     enclave_manifest_data: &[u8],
 ) -> std::result::Result<(), IoError> {
-    let run_cmd = GenericEnclaveImageBuilder::enclave_command_string(
-        enclave_settings,
-        &Path::new(INSTALLATION_DIR),
-        "enclave",
-    );
+    let run_cmd = get_run_cmd(&enclave_settings);
 
     let mut blobs_dir = PathBuf::from(format!("{}/blobs", INSTALLATION_DIR));
     let init = {
@@ -136,7 +132,7 @@ fn create_initramfs(
     };
 
     let mut fs_tree = FsTree::new()
-        .add_file("env", Cursor::new(enclave_settings.env_vars.join("\n")))
+        .add_file("env", Cursor::new(get_env_vars(&enclave_settings.env_vars)))
         .add_file("cmd", Cursor::new(run_cmd))
         .add_executable("init", Cursor::new(init));
 
@@ -144,14 +140,16 @@ fn create_initramfs(
     info!("Adding enclave-base filesystem to initramfs rootfs...");
     fs_tree = add_enclave_base_to_initramfs(fs_tree, &mut enclave_base_archive)?;
 
-    // Ensure basic rootfs structure exists for `init`, even if missing from enclave-base.
+    // Set up minimal runtime directories. Do not create directories that exist
+    // in the target rootfs (e.g., /bin). Since we use mount --move to transition
+    // to the new root, pre-existing directories in the initramfs can interfere
+    // with the visibility of the rootfs contents or break symbolic links.
     fs_tree = fs_tree
         .add_directory("rootfs/dev")
         .add_directory("rootfs/proc")
         .add_directory("rootfs/run")
         .add_directory("rootfs/sys")
-        .add_directory("rootfs/tmp")
-        .add_directory("rootfs/bin");
+        .add_directory("rootfs/tmp");
 
     // Add dependencies available as resource
     for resource in GenericEnclaveImageBuilder::IMAGE_BUILD_DEPENDENCIES {
@@ -265,4 +263,24 @@ fn add_enclave_base_to_initramfs(
     }
 
     Ok(fs_tree)
+}
+
+// Extends the env variables set in conversion request with
+// the ones expected by `init` binary.
+fn get_env_vars(enclave_env_vars: &Vec<String>) -> String {
+    let mut env_vars = enclave_env_vars.clone();
+    // Add PATH env variables.
+    env_vars.push("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_owned());
+    env_vars.join("\n")
+}
+
+// Formats the command based on the expectation of `init` binary.
+fn get_run_cmd(enclave_settings: &EnclaveSettings) -> String {
+    let run_cmd = GenericEnclaveImageBuilder::enclave_command_string(
+        enclave_settings,
+        &Path::new(INSTALLATION_DIR),
+        "enclave",
+    );
+
+    format!("/bin/sh\n-c\n{}", run_cmd)
 }

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -78,11 +78,11 @@ impl<'a> EnclaveImageBuilder<'a> {
             .export_enclave_base_file_system(input_repository, &enclave_base_tar_path)
             .await?;
 
-        let output_file_path = work_dir.join(Self::INITRAMFS_FILENAME);
+        let initramfs_file_path = work_dir.join(Self::INITRAMFS_FILENAME);
 
         info!("Creating initramfs archive...");
         create_initramfs(
-            &output_file_path,
+            &initramfs_file_path,
             enclave_base_archive,
             &enclave_settings,
             &enclave_manifest_data,
@@ -105,7 +105,7 @@ impl<'a> EnclaveImageBuilder<'a> {
         compute_snp_launch_measurement(&SnpMeasurementInputs {
             ovmf: &ovmf_path,
             kernel: &kernel_path,
-            initrd: Some(&output_file_path),
+            initrd: Some(&initramfs_file_path),
             cmdline: None,
             vcpus: 1,
         })

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -10,12 +10,14 @@ use std::{env, fs};
 
 use api_model::enclave::{EnclaveManifest, UserConfig};
 use api_model::snp::{SNPEnclavesConversionRequestOptions, SNPEnclavesMeasurements};
-use api_model::HexString;
 use fortanix_vme_initramfs::{FsTree, Initramfs};
 use log::{info, warn};
 use nix::sys::stat::SFlag;
 use tar::{Archive, EntryType};
 
+use crate::image_builder::enclave::snp_measurement::{
+    compute_snp_launch_measurement, SnpMeasurementInputs,
+};
 use crate::image_builder::enclave::EnclaveImageBuilder as GenericEnclaveImageBuilder;
 use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::parent::snp::{BLOBS_SUBDIR_GPU_DISABLED, BLOBS_SUBDIR_GPU_ENABLED};
@@ -90,9 +92,24 @@ impl<'a> EnclaveImageBuilder<'a> {
             kind: ConverterErrorKind::EnclaveImageCreation,
         })?;
 
-        Ok(SNPEnclavesMeasurements {
-            launch_measurement: HexString::new(vec![0; 48]),
+        let blobs_dir = Path::new(INSTALLATION_DIR).join("blobs");
+        let ovmf_path = blobs_dir.join("OVMF.amdsev.fd");
+        let kernel_path = blobs_dir
+            .join(if enclave_settings.gpu_passthrough {
+                BLOBS_SUBDIR_GPU_ENABLED
+            } else {
+                BLOBS_SUBDIR_GPU_DISABLED
+            })
+            .join("bzImage");
+
+        compute_snp_launch_measurement(&SnpMeasurementInputs {
+            ovmf: &ovmf_path,
+            kernel: &kernel_path,
+            initrd: Some(&output_file_path),
+            cmdline: None,
+            vcpus: 1,
         })
+        .await
     }
 
     pub(crate) fn get_enclave_base_image_name(

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -92,24 +92,7 @@ impl<'a> EnclaveImageBuilder<'a> {
             kind: ConverterErrorKind::EnclaveImageCreation,
         })?;
 
-        let blobs_dir = Path::new(INSTALLATION_DIR).join("blobs");
-        let ovmf_path = blobs_dir.join("OVMF.amdsev.fd");
-        let kernel_path = blobs_dir
-            .join(if enclave_settings.gpu_passthrough {
-                BLOBS_SUBDIR_GPU_ENABLED
-            } else {
-                BLOBS_SUBDIR_GPU_DISABLED
-            })
-            .join("bzImage");
-
-        compute_snp_launch_measurement(&SnpMeasurementInputs {
-            ovmf: &ovmf_path,
-            kernel: &kernel_path,
-            initrd: Some(&initramfs_file_path),
-            cmdline: None,
-            vcpus: 2,
-        })
-        .await
+        compute_launch_measurements(&enclave_settings, &initramfs_file_path).await
     }
 
     pub(crate) fn get_enclave_base_image_name(
@@ -214,6 +197,30 @@ fn create_initramfs(
 
     info!("Built initramfs.gz at {}", output_path.display());
     Ok(())
+}
+
+async fn compute_launch_measurements(
+    enclave_settings: &EnclaveSettings,
+    initramfs_file_path: &Path,
+) -> Result<SNPEnclavesMeasurements> {
+    let blobs_dir = Path::new(INSTALLATION_DIR).join("blobs");
+    let ovmf_path = blobs_dir.join("OVMF.amdsev.fd");
+    let kernel_path = blobs_dir
+        .join(if enclave_settings.gpu_passthrough {
+            BLOBS_SUBDIR_GPU_ENABLED
+        } else {
+            BLOBS_SUBDIR_GPU_DISABLED
+        })
+        .join("bzImage");
+
+    compute_snp_launch_measurement(&SnpMeasurementInputs {
+        ovmf: &ovmf_path,
+        kernel: &kernel_path,
+        initrd: Some(initramfs_file_path),
+        cmdline: None,
+        vcpus: 2,
+    })
+    .await
 }
 
 fn add_enclave_base_to_initramfs(

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -107,7 +107,7 @@ impl<'a> EnclaveImageBuilder<'a> {
             kernel: &kernel_path,
             initrd: Some(&initramfs_file_path),
             cmdline: None,
-            vcpus: 1,
+            vcpus: 2,
         })
         .await
     }

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -32,6 +32,7 @@ impl<'a> EnclaveImageBuilder<'a> {
     const INIT_BIN: &'static str = "init";
     const GPU_MODULES: &'static [&'static str] = &["nvidia.ko", "nvidia-uvm.ko"];
     pub const INITRAMFS_FILENAME: &'static str = "initramfs.gz";
+    pub const OVMF_FILENAME: &'static str = "OVMF.amdsev.fd";
 
     pub(crate) async fn create_image(
         &self,
@@ -204,7 +205,7 @@ async fn compute_launch_measurements(
     initramfs_file_path: &Path,
 ) -> Result<SNPEnclavesMeasurements> {
     let blobs_dir = Path::new(INSTALLATION_DIR).join("blobs");
-    let ovmf_path = blobs_dir.join("OVMF.amdsev.fd");
+    let ovmf_path = blobs_dir.join(EnclaveImageBuilder::OVMF_FILENAME);
     let kernel_path = blobs_dir
         .join(if enclave_settings.gpu_passthrough {
             BLOBS_SUBDIR_GPU_ENABLED

--- a/tools/container-converter/src/image_builder/enclave/snp_measurement.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp_measurement.rs
@@ -1,0 +1,62 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use api_model::snp::SNPEnclavesMeasurements;
+use api_model::HexString;
+
+use crate::{run_subprocess, ConverterError, ConverterErrorKind, Result};
+
+const MEASURE_SCRIPT: &str = "/opt/sev-snp-measure/measure.py";
+
+pub(crate) struct SnpMeasurementInputs<'a> {
+    pub ovmf: &'a Path,
+    pub kernel: &'a Path,
+    pub initrd: Option<&'a Path>,
+    pub cmdline: Option<&'a str>,
+    pub vcpus: u8,
+}
+
+pub(crate) async fn compute_snp_launch_measurement(
+    inputs: &SnpMeasurementInputs<'_>,
+) -> Result<SNPEnclavesMeasurements> {
+    let mut args: Vec<OsString> = vec![
+        "--ovmf".into(),
+        inputs.ovmf.as_os_str().to_os_string(),
+        "--kernel".into(),
+        inputs.kernel.as_os_str().to_os_string(),
+        "--vcpus".into(),
+        inputs.vcpus.to_string().into(),
+    ];
+    if let Some(initrd) = inputs.initrd {
+        args.push("--initrd".into());
+        args.push(initrd.as_os_str().to_os_string());
+    }
+    if let Some(cmdline) = inputs.cmdline {
+        args.push("--cmdline".into());
+        args.push(cmdline.into());
+    }
+
+    let stdout = run_subprocess(MEASURE_SCRIPT, &args)
+        .await
+        .map_err(|message| ConverterError {
+            message: format!("Failed to compute SNP launch measurement: {}", message),
+            kind: ConverterErrorKind::EnclaveImageCreation,
+        })?;
+
+    let hex = stdout.trim();
+    let launch_measurement = HexString::from_str(hex).map_err(|err| ConverterError {
+        message: format!(
+            "measure.py produced an invalid hex measurement {:?}: {}",
+            hex, err
+        ),
+        kind: ConverterErrorKind::EnclaveImageCreation,
+    })?;
+
+    Ok(SNPEnclavesMeasurements { launch_measurement })
+}

--- a/tools/sev-snp-measure/measure.py
+++ b/tools/sev-snp-measure/measure.py
@@ -15,7 +15,7 @@ from sevsnpmeasure.sev_mode import SevMode
 
 FORTANIX_VME_VCPU_SIG = 0
 # TODO: needs security hardening.
-FORTANIX_VME_GUEST_FEATURES = 0x21
+FORTANIX_VME_GUEST_FEATURES = 1
 
 
 def main() -> int:

--- a/tools/sev-snp-measure/measure.py
+++ b/tools/sev-snp-measure/measure.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Fortanix, Inc.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import sys
+from pathlib import Path
+
+from sevsnpmeasure.guest import calc_launch_digest
+from sevsnpmeasure.sev_mode import SevMode
+
+FORTANIX_VME_VCPU_SIG = 0
+# TODO: needs security hardening.
+FORTANIX_VME_GUEST_FEATURES = 0x21
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute the SNP launch measurement for an SNP image.",
+    )
+    parser.add_argument("--ovmf", required=True, type=Path,
+                        help="Path to the OVMF firmware binary.")
+    parser.add_argument("--kernel", required=True, type=Path,
+                        help="Path to the kernel image (or UKI).")
+    parser.add_argument("--initrd", type=Path, default=None,
+                        help="Path to the initrd. Omit for UKI inputs.")
+    parser.add_argument("--cmdline", type=str, default=None,
+                        help="Kernel command line. Omit for UKI inputs.")
+    parser.add_argument("--vcpus", required=True, type=int,
+                        help="Number of vCPUs.")
+    args = parser.parse_args()
+
+    try:
+        digest = calc_launch_digest(
+            mode=SevMode.SEV_SNP,
+            vcpus=args.vcpus,
+            vcpu_sig=FORTANIX_VME_VCPU_SIG,
+            ovmf_file=str(args.ovmf),
+            kernel=str(args.kernel),
+            initrd=str(args.initrd) if args.initrd else None,
+            append=args.cmdline,
+            guest_features=FORTANIX_VME_GUEST_FEATURES,
+        )
+    except (RuntimeError, OSError) as e:
+        print(f"Error computing launch measurement: {e}", file=sys.stderr)
+        return 1
+
+    hex_measurement = digest.hex() if isinstance(digest, (bytes, bytearray)) else str(digest)
+    print(hex_measurement)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sev-snp-measure/requirements.txt
+++ b/tools/sev-snp-measure/requirements.txt
@@ -1,1 +1,1 @@
-sev-snp-measure @ git+https://github.com/fortanix/sev-snp-measure.git@887f3812b61943672f6d5420043192195b2584ef
+sev-snp-measure @ git+https://github.com/virtee/sev-snp-measure.git@5b6a79e86641a7ca1a377ba1848d1dcdc2498494

--- a/tools/sev-snp-measure/requirements.txt
+++ b/tools/sev-snp-measure/requirements.txt
@@ -1,0 +1,1 @@
+sev-snp-measure @ git+https://github.com/fortanix/sev-snp-measure.git@887f3812b61943672f6d5420043192195b2584ef


### PR DESCRIPTION
What's in this PR:

- tools/sev-snp-measure/ - small Python wrapper around the sev-snp-measure tool.
- tools/container-converter/.../snp_measurement.rs - Rust function                        compute_snp_launch_measurement that runs the Python wrapper and returns the result to the caller.
- docker/snp/Dockerfile - minimal Dockerfile that installs the tooling into the SNP converter image. RTE-941 extends this with everything else.
Depends on #72 