### PR TITLE
RTE-917: Add support for platforms SNP and Simulator in vsock-proxy

### DIFF
--- a/build-support/src/lib.rs
+++ b/build-support/src/lib.rs
@@ -9,6 +9,8 @@ pub const PLATFORM_ENV: &str = "SALMIAC_PLATFORM";
 #[strum(serialize_all = "snake_case")]
 pub enum Platform {
     Nitro,
+    Simulator,
+    Snp,
 }
 
 impl Platform {

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "ipnetwork",
  "log 0.4.14",
  "rtnetlink",
+ "salmiac-build-support",
  "serde",
  "serde_cbor",
  "threadpool",

--- a/vsock-proxy/Cargo.lock
+++ b/vsock-proxy/Cargo.lock
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cache-padded"
@@ -366,6 +366,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -711,7 +717,7 @@ dependencies = [
  "shared",
  "sysinfo",
  "tokio",
- "tokio-vsock",
+ "tokio-vsock 0.3.1",
  "tun",
  "url 2.3.1",
  "uuid 0.7.4",
@@ -1222,9 +1228,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1472,7 +1478,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.11.1",
  "futures 0.3.16",
  "log 0.4.14",
  "netlink-packet-core",
@@ -1555,6 +1561,19 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -1705,7 +1724,7 @@ dependencies = [
  "shared",
  "tempdir",
  "tokio",
- "tokio-vsock",
+ "tokio-vsock 0.3.1",
  "tun",
 ]
 
@@ -2313,7 +2332,7 @@ dependencies = [
  "serde_cbor",
  "threadpool",
  "tokio",
- "tokio-vsock",
+ "tokio-vsock 0.7.2",
  "tun",
 ]
 
@@ -2562,7 +2581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
- "bytes 1.0.1",
+ "bytes 1.11.1",
  "libc",
  "mio",
  "num_cpus",
@@ -2591,7 +2610,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "log 0.4.14",
@@ -2609,7 +2628,20 @@ dependencies = [
  "futures 0.3.16",
  "libc",
  "tokio",
- "vsock",
+ "vsock 0.2.4",
+]
+
+[[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes 1.11.1",
+ "futures 0.3.16",
+ "libc",
+ "tokio",
+ "vsock 0.5.4",
 ]
 
 [[package]]
@@ -2625,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cb3f24867499300ae21771a95bbaede2761497ae51094bbefcfd40646815b2a"
 dependencies = [
  "byteorder",
- "bytes 1.0.1",
+ "bytes 1.11.1",
  "futures-core",
  "ioctl-sys",
  "libc",
@@ -2797,6 +2829,16 @@ checksum = "c932be691560e8f3f7b2be5a47df1b8f45387e1d1df40d45b2e62284b9e9150e"
 dependencies = [
  "libc",
  "nix 0.19.1",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix 0.31.3",
 ]
 
 [[package]]

--- a/vsock-proxy/parent/Cargo.toml
+++ b/vsock-proxy/parent/Cargo.toml
@@ -27,8 +27,5 @@ tokio = { version = "1.21.1", features = ["macros", "rt", "rt-multi-thread", "io
 tokio-vsock = "0.3.1"
 tun = { version = "0.5.3", features = ["async"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "deny" }
-
 [build-dependencies]
 salmiac-build-support = { path = "../../build-support" }

--- a/vsock-proxy/parent/src/main.rs
+++ b/vsock-proxy/parent/src/main.rs
@@ -4,6 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
+
 mod network;
 mod packet_capture;
 mod parent;

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -22,7 +22,7 @@ use shared::socket::{AsyncReadLvStream, AsyncWriteLvStream};
 use shared::tap::{start_tap_loops, PRIVATE_TAP_MTU, PRIVATE_TAP_NAME};
 use shared::{
     cleanup_tokio_tasks, run_subprocess, run_subprocess_with_output_setup, with_background_tasks, AppLogPortInfo,
-    CommandOutputConfig, StreamType, DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, NS_SWITCH_FILE, VSOCK_PARENT_CID,
+    CommandOutputConfig, StreamType, DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, NS_SWITCH_FILE, VSOCK_LISTENER_CID,
 };
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
@@ -607,8 +607,8 @@ async fn create_vsock_stream(port: u32) -> Result<AsyncVsockStream, String> {
 }
 
 pub(crate) fn listen_to_parent(port: u32) -> Result<AsyncVsockListener, String> {
-    AsyncVsockListener::bind(VSOCK_PARENT_CID, port)
-        .map_err(|_| format!("Could not bind to cid: {}, port: {}", VSOCK_PARENT_CID, port))
+    AsyncVsockListener::bind(VSOCK_LISTENER_CID, port)
+        .map_err(|_| format!("Could not bind to cid: {}, port: {}", VSOCK_LISTENER_CID, port))
 }
 
 pub(crate) async fn accept(listener: &mut AsyncVsockListener) -> Result<AsyncVsockStream, String> {

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{env, fs};
@@ -26,6 +26,7 @@ use shared::{
 };
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
+use tokio::time::{sleep, Duration, Instant};
 use tokio_vsock::{VsockListener as AsyncVsockListener, VsockStream as AsyncVsockStream};
 
 use crate::network::{
@@ -55,6 +56,10 @@ const VSOCK_PARENT_PORT: u32 = 5006;
 const NAMESERVER_KEYWORD: &'static str = "nameserver";
 
 const CLIENT_LOG_STREAMS: [StreamType; 2] = [StreamType::Stdout, StreamType::Stderr];
+
+const NBD_SERVER_READY_TIMEOUT: Duration = Duration::from_secs(5);
+const NBD_SERVER_READY_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+const TCP_LISTEN_STATE: &str = "0A";
 
 async fn message_handler(enclave: &mut AsyncVsockStream) -> Result<UserProgramExitStatus, String> {
     loop {
@@ -98,7 +103,7 @@ pub(crate) async fn run(args: ParentConsoleArguments) -> Result<UserProgramExitS
     let tap_l3_address = setup_result.private_tap.tap_l3_address.ip();
 
     let mut log_listeners = setup_log_listeners(tap_l3_address).await?;
-    let mut background_tasks = start_background_tasks(setup_result)?;
+    let mut background_tasks = start_background_tasks(setup_result).await?;
 
     let log_ports = get_log_sock_addrs(&mut log_listeners)?;
     info!("Client log listeners set up.");
@@ -326,6 +331,39 @@ async fn run_nbd_server(port: u16) -> Result<(), String> {
     }
 }
 
+async fn wait_for_nbd_server(address: IpAddr, port: u16) -> Result<(), String> {
+    let address = match address {
+        IpAddr::V4(address) => address,
+        IpAddr::V6(address) => return Err(format!("IPv6 NBD readiness check is not supported for {address}")),
+    };
+
+    let start = Instant::now();
+
+    while start.elapsed() < NBD_SERVER_READY_TIMEOUT {
+        if tcp_port_is_listening(address, port)? {
+            return Ok(());
+        }
+
+        sleep(NBD_SERVER_READY_RETRY_INTERVAL).await;
+    }
+
+    Err(format!(
+        "nbd-server did not start listening on {address}:{port} within {:?}",
+        NBD_SERVER_READY_TIMEOUT
+    ))
+}
+
+fn tcp_port_is_listening(address: Ipv4Addr, port: u16) -> Result<bool, String> {
+    let expected = format!("{:08X}:{port:04X}", u32::from_le_bytes(address.octets()));
+    let proc_net_tcp = fs::read_to_string("/proc/net/tcp").map_err(|err| format!("failed to read /proc/net/tcp: {err}"))?;
+
+    Ok(proc_net_tcp.lines().skip(1).any(|line| {
+        let fields = line.split_whitespace().collect::<Vec<_>>();
+
+        fields.len() > 3 && fields[1].eq_ignore_ascii_case(&expected) && fields[3] == TCP_LISTEN_STATE
+    }))
+}
+
 /// Start the dnsmasq process. dnsmasq is a DNS server/proxy. We configure dnsmasq to listen
 /// on the fortanix-tap0 device, so that device must be set up first before we start dnsmasq.
 /// dnsmasq will refuse to run if the configured interface is not present when it starts.
@@ -372,7 +410,7 @@ async fn run_log_listeners(listeners_info: Vec<(TcpListener, StreamType)>) -> Re
     Ok(tasks)
 }
 
-fn start_background_tasks(
+async fn start_background_tasks(
     parent_setup_result: ParentSetupResult,
 ) -> Result<FuturesUnordered<JoinHandle<Result<(), String>>>, String> {
     let result = FuturesUnordered::new();
@@ -385,21 +423,27 @@ fn start_background_tasks(
     }
 
     let private_device = parent_setup_result.private_tap;
+    let private_tap_l3_address = private_device.tap_l3_address.ip();
     let private_tap_loops = start_tap_loops(private_device.tap, private_device.vsock, PRIVATE_TAP_MTU);
 
     result.push(private_tap_loops.tap_to_vsock);
     result.push(private_tap_loops.vsock_to_tap);
 
-    write_nbd_config(private_device.tap_l3_address.ip(), NBD_EXPORTS)?;
+    write_nbd_config(private_tap_l3_address, NBD_EXPORTS)?;
 
     for export_config in NBD_EXPORTS {
         let nbd_process = tokio::spawn(run_nbd_server(export_config.port));
         info!(
-            "Started nbd server on port {} serving block file {}",
+            "Spawned nbd server on port {} serving block file {}",
             export_config.port, export_config.block_file_path
         );
 
         result.push(nbd_process);
+    }
+
+    for export_config in NBD_EXPORTS {
+        wait_for_nbd_server(private_tap_l3_address, export_config.port).await?;
+        info!("NBD server on port {} is ready.", export_config.port);
     }
 
     if parent_setup_result.start_dnsmasq {

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -358,9 +358,11 @@ fn tcp_port_is_listening(address: Ipv4Addr, port: u16) -> Result<bool, String> {
     let proc_net_tcp = fs::read_to_string("/proc/net/tcp").map_err(|err| format!("failed to read /proc/net/tcp: {err}"))?;
 
     Ok(proc_net_tcp.lines().skip(1).any(|line| {
-        let fields = line.split_whitespace().collect::<Vec<_>>();
+        let mut fields = line.split_whitespace();
+        let Some(listen_addr) = fields.nth(1) else { return false };
+        let Some(listen_state) = fields.nth(1) else { return false };
 
-        fields.len() > 3 && fields[1].eq_ignore_ascii_case(&expected) && fields[3] == TCP_LISTEN_STATE
+        listen_addr.eq_ignore_ascii_case(&expected) && listen_state == TCP_LISTEN_STATE
     }))
 }
 

--- a/vsock-proxy/parent/src/platform/mod.rs
+++ b/vsock-proxy/parent/src/platform/mod.rs
@@ -10,11 +10,27 @@ use tokio::task::JoinHandle;
 #[cfg(platform = "nitro")]
 mod nitro;
 
+#[cfg(platform = "simulator")]
+mod simulator;
+
+#[cfg(platform = "snp")]
+mod snp;
+
 pub(crate) type GuestTasks = FuturesUnordered<JoinHandle<Result<(), String>>>;
 
-pub(crate) struct GuestLaunchResult {
-    pub(crate) enclave_process: JoinHandle<Result<(), String>>,
-}
+#[cfg(platform = "simulator")]
+pub(crate) use simulator::{
+    launch_guest,
+    should_forward_client_logs,
+    start_post_connect_guest_tasks,
+};
+
+#[cfg(platform = "snp")]
+pub(crate) use snp::{
+    launch_guest,
+    should_forward_client_logs,
+    start_post_connect_guest_tasks,
+};
 
 #[cfg(platform = "nitro")]
 pub(crate) use nitro::{
@@ -22,3 +38,7 @@ pub(crate) use nitro::{
     should_forward_client_logs,
     start_post_connect_guest_tasks,
 };
+
+pub(crate) struct GuestLaunchResult {
+    pub(crate) enclave_process: JoinHandle<Result<(), String>>,
+}

--- a/vsock-proxy/parent/src/platform/simulator.rs
+++ b/vsock-proxy/parent/src/platform/simulator.rs
@@ -1,0 +1,82 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use std::path::Path;
+
+use shared::run_subprocess;
+
+use super::{GuestLaunchResult, GuestTasks};
+
+const QEMU_BINARY: &str = "qemu-system-x86_64";
+
+const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/kernel";
+const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.cpio.gz";
+
+const CPU_COUNT: &str = "2";
+const MEMORY_SIZE: &str = "2048";
+
+const KERNEL_CMDLINE: &str = "console=ttyS0 rdinit=/init loglevel=7";
+
+pub(crate) fn should_forward_client_logs() -> bool {
+    true
+}
+
+pub(crate) fn launch_guest() -> GuestLaunchResult {
+    let enclave_process = tokio::spawn(start_simulator_guest());
+
+    GuestLaunchResult {
+        enclave_process,
+    }
+}
+
+pub(crate) fn start_post_connect_guest_tasks() -> GuestTasks {
+    GuestTasks::new()
+}
+
+
+async fn start_simulator_guest() -> Result<(), String> {
+    require_file("simulator kernel", KERNEL_PATH)?;
+    require_file("simulator initramfs", INITRAMFS_PATH)?;
+    require_file("KVM device", "/dev/kvm")?;
+
+    let args = [
+        "-enable-kvm",
+        "-cpu",
+        "host",
+        "-m",
+        MEMORY_SIZE,
+        "-smp",
+        CPU_COUNT,
+        "-display",
+        "none",
+        "-serial",
+        "telnet:0.0.0.0:4321,server,wait",
+        "-monitor",
+        "none",
+        "-no-reboot",
+        "-kernel",
+        KERNEL_PATH,
+        "-initrd",
+        INITRAMFS_PATH,
+        "-append",
+        KERNEL_CMDLINE,
+        "-device",
+        "vhost-vsock-pci,guest-cid=3"
+    ];
+
+    run_subprocess(
+        QEMU_BINARY,
+        &args,
+    )
+    .await
+}
+
+fn require_file(description: &str, path: &str) -> Result<(), String> {
+    if Path::new(path).exists() {
+        Ok(())
+    } else {
+        Err(format!("{description} not found at {path}"))
+    }
+}

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -1,0 +1,130 @@
+use std::env;
+use std::path::Path;
+
+use shared::run_subprocess;
+
+use super::{GuestLaunchResult, GuestTasks};
+
+const QEMU_BINARY: &str = "qemu-system-x86_64";
+
+const OVMF_PATH: &str = "/opt/fortanix/enclave-os/OVMF.amdsev.fd";
+
+const CPU_COUNT: &str = "2";
+const MEMORY_SIZE: &str = "8192M";
+
+/// - Use host passthrough, see https://www.qemu.org/docs/master/system/i386/cpu.html
+/// - Unset TSA_L1_NO and TSA_SQ_NO:
+///   See: https://www.amd.com/content/dam/amd/en/documents/resources/bulletin/technical-guidance-for-mitigating-transient-scheduler-attacks.pdf
+///   "the SEV-SNP FW will not allow the hypervisor to set the TSA_L1_NO or TSA_SQ_NO CPUID bits"
+/// - TODO(before merge): Confirm family=0,model=0,stepping=0
+const DEFAULT_CPU: &str = "host,-tsa-sq-no,-tsa-l1-no,family=0,model=0,stepping=0";
+
+// https://docs.amd.com/v/u/en-US/58207-using-sev-with-amd-epyc-processors
+//
+// "Since SNP is only supported from processor series 7003 and newer, the c-bit (cbitpos) will always be 51"
+const DEFAULT_CBITPOS: &str = "51";
+const DEFAULT_REDUCED_PHYS_BITS: &str = "1";
+
+// We want SMT disabled
+const DEFAULT_POLICY: &str = "0x20000";
+
+// TODO(before merge): Make UKI instead, and need to check on final kernel cmdline
+const KERNEL_CMDLINE: &str = "console=ttyS0 rdinit=/init loglevel=7";
+const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/kernel";
+const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.cpio.gz";
+
+const SNP_GUEST_ID: &str = "sev0";
+const MEMORY_BACKEND_ID: &str = "ram1";
+
+// TODO(before merge): need to  currently like this for debugging
+const SERIAL: &str = "telnet:0.0.0.0:4321,server,wait";
+
+// TODO: We need to see how we will assign guest CID when we support multiple
+// containers on single host
+const VSOCK_DEVICE: &str = "vhost-vsock-pci,guest-cid=3";
+
+pub(crate) fn should_forward_client_logs() -> bool {
+    true
+}
+
+pub(crate) fn launch_guest() -> GuestLaunchResult {
+    let enclave_process = tokio::spawn(start_snp_guest());
+
+    GuestLaunchResult { enclave_process }
+}
+
+pub(crate) fn start_post_connect_guest_tasks() -> GuestTasks {
+    GuestTasks::new()
+}
+
+async fn start_snp_guest() -> Result<(), String> {
+    require_file("SNP kernel", KERNEL_PATH)?;
+    require_file("SNP initramfs", INITRAMFS_PATH)?;
+    require_file("SNP OVMF firmware", OVMF_PATH)?;
+    require_file("KVM device", "/dev/kvm")?;
+    require_file("SEV device", "/dev/sev")?;
+
+    let cpu = env_or_default("SNP_CPU", DEFAULT_CPU);
+    let cbitpos = env_or_default("SNP_CBITPOS", DEFAULT_CBITPOS);
+    let reduced_phys_bits = env_or_default("SNP_REDUCED_PHYS_BITS", DEFAULT_REDUCED_PHYS_BITS);
+    let policy = env_or_default("SNP_POLICY", DEFAULT_POLICY);
+
+    let machine = format!(
+        "q35,confidential-guest-support={SNP_GUEST_ID},vmport=off,memory-backend={MEMORY_BACKEND_ID}"
+    );
+
+    let memory_backend = format!(
+        "memory-backend-memfd,id={MEMORY_BACKEND_ID},size={MEMORY_SIZE},share=true,prealloc=false"
+    );
+
+    let snp_guest = format!(
+        "sev-snp-guest,id={SNP_GUEST_ID},cbitpos={cbitpos},reduced-phys-bits={reduced_phys_bits},kernel-hashes=on,policy={policy}"
+    );
+
+    let args = [
+        "-enable-kvm",
+        "-display",
+        "none",
+        "-serial",
+        SERIAL,
+        "-monitor",
+        "none",
+        "-no-reboot",
+        "-machine",
+        &machine,
+        "-cpu",
+        &cpu,
+        "-smp",
+        CPU_COUNT,
+        "-m",
+        MEMORY_SIZE,
+        "-object",
+        &memory_backend,
+        "-object",
+        &snp_guest,
+        "-bios",
+        OVMF_PATH,
+        "-kernel",
+        KERNEL_PATH,
+        "-initrd",
+        INITRAMFS_PATH,
+        "-append",
+        KERNEL_CMDLINE,
+        "-device",
+        VSOCK_DEVICE,
+    ];
+
+    run_subprocess(QEMU_BINARY, &args).await
+}
+
+fn env_or_default(name: &str, default: &str) -> String {
+    env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+fn require_file(description: &str, path: &str) -> Result<(), String> {
+    if Path::new(path).exists() {
+        Ok(())
+    } else {
+        Err(format!("{description} not found at {path}"))
+    }
+}

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -43,6 +43,11 @@ const SERIAL: &str = "telnet:0.0.0.0:4321,server,wait";
 // containers on single host
 const VSOCK_DEVICE: &str = "vhost-vsock-pci,guest-cid=3";
 
+const IOMMUFD_ID: &str = "iommufd0";
+const IOMMUFD_OBJECT: &str = "iommufd,id=iommufd0";
+const GPU_ROOT_PORT: &str = "pcie-root-port,id=pci.1,bus=pcie.0";
+const FW_CFG_MMIO64: &str = "name=opt/ovmf/X-PciMmio64Mb,string=262144";
+
 pub(crate) fn should_forward_client_logs() -> bool {
     true
 }
@@ -81,7 +86,18 @@ async fn start_snp_guest() -> Result<(), String> {
         "sev-snp-guest,id={SNP_GUEST_ID},cbitpos={cbitpos},reduced-phys-bits={reduced_phys_bits},kernel-hashes=on,policy={policy}"
     );
 
-    let args = [
+    let gpu_device = match env::var("SNP_GPU_BDF") {
+        Ok(gpu_bdf) => {
+            require_vfio_device(&gpu_bdf)?;
+            require_file("IOMMUFD device", "/dev/iommu")?;
+            Some(format!(
+                "vfio-pci,host={gpu_bdf},bus=pci.1,iommufd={IOMMUFD_ID},romfile="
+            ))
+        }
+        Err(_) => None,
+    };
+
+    let mut args = vec![
         "-enable-kvm",
         "-display",
         "none",
@@ -114,6 +130,19 @@ async fn start_snp_guest() -> Result<(), String> {
         VSOCK_DEVICE,
     ];
 
+    if let Some(gpu_device) = gpu_device.as_deref() {
+        args.extend([
+            "-object",
+            IOMMUFD_OBJECT,
+            "-device",
+            GPU_ROOT_PORT,
+            "-device",
+            gpu_device,
+            "-fw_cfg",
+            FW_CFG_MMIO64,
+        ]);
+    }
+
     run_subprocess(QEMU_BINARY, &args).await
 }
 
@@ -127,4 +156,31 @@ fn require_file(description: &str, path: &str) -> Result<(), String> {
     } else {
         Err(format!("{description} not found at {path}"))
     }
+}
+
+fn require_vfio_device(bdf: &str) -> Result<(), String> {
+    let device_path = format!("/sys/bus/pci/devices/{bdf}");
+    require_file("GPU PCI device", &device_path)?;
+
+    let driver_path = format!("{device_path}/driver");
+    let driver = std::fs::read_link(&driver_path)
+        .map_err(|e| format!("failed reading GPU driver at {driver_path}: {e}"))?;
+
+    if driver.file_name().and_then(|name| name.to_str()) != Some("vfio-pci") {
+        return Err(format!("GPU {bdf} is not bound to vfio-pci"));
+    }
+
+    require_file("VFIO control device", "/dev/vfio/vfio")?;
+
+    let iommu_group_path = format!("{device_path}/iommu_group");
+    let iommu_group = std::fs::read_link(&iommu_group_path)
+        .map_err(|e| format!("failed reading IOMMU group for GPU {bdf}: {e}"))?;
+
+    let group = iommu_group
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("invalid IOMMU group path for GPU {bdf}"))?;
+
+    let vfio_group_path = format!("/dev/vfio/{group}");
+    require_file("VFIO group device", &vfio_group_path)
 }

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -28,7 +28,6 @@ const DEFAULT_REDUCED_PHYS_BITS: &str = "1";
 // We want SMT disabled
 const DEFAULT_POLICY: &str = "0x20000";
 
-// TODO(before merge): Make UKI instead, and need to check on final kernel cmdline
 const KERNEL_CMDLINE: &str = "console=ttyS0 rdinit=/init loglevel=7";
 const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/bzImage";
 const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.gz";

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -17,7 +17,7 @@ const MEMORY_SIZE: &str = "8192M";
 ///   See: https://www.amd.com/content/dam/amd/en/documents/resources/bulletin/technical-guidance-for-mitigating-transient-scheduler-attacks.pdf
 ///   "the SEV-SNP FW will not allow the hypervisor to set the TSA_L1_NO or TSA_SQ_NO CPUID bits"
 /// - TODO(before merge): Confirm family=0,model=0,stepping=0
-const DEFAULT_CPU: &str = "host,-tsa-sq-no,-tsa-l1-no,family=0,model=0,stepping=0";
+const DEFAULT_CPU: &str = "EPYC-v4,-tsa-sq-no,-tsa-l1-no,family=0,model=0,stepping=0";
 
 // https://docs.amd.com/v/u/en-US/58207-using-sev-with-amd-epyc-processors
 //
@@ -30,8 +30,8 @@ const DEFAULT_POLICY: &str = "0x20000";
 
 // TODO(before merge): Make UKI instead, and need to check on final kernel cmdline
 const KERNEL_CMDLINE: &str = "console=ttyS0 rdinit=/init loglevel=7";
-const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/kernel";
-const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.cpio.gz";
+const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/bzImage";
+const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.gz";
 
 const SNP_GUEST_ID: &str = "sev0";
 const MEMORY_BACKEND_ID: &str = "ram1";

--- a/vsock-proxy/shared/Cargo.toml
+++ b/vsock-proxy/shared/Cargo.toml
@@ -22,3 +22,6 @@ threadpool = "1.7.1"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "io-util", "net"] }
 tokio-vsock = "0.3.1"
 tun = { version = "0.5.3", features = ["async"] }
+
+[build-dependencies]
+salmiac-build-support = { path = "../../build-support" }

--- a/vsock-proxy/shared/Cargo.toml
+++ b/vsock-proxy/shared/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_cbor = "0.11.2"
 threadpool = "1.7.1"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread", "io-util", "net"] }
-tokio-vsock = "0.3.1"
+tokio-vsock = "0.7"
 tun = { version = "0.5.3", features = ["async"] }
 
 [build-dependencies]

--- a/vsock-proxy/shared/build.rs
+++ b/vsock-proxy/shared/build.rs
@@ -1,0 +1,7 @@
+use salmiac_build_support::Platform;
+
+fn main() {
+    if let Err(err) = Platform::emit_cfg_from_env() {
+        panic!("{}", err);
+    }
+}

--- a/vsock-proxy/shared/src/lib.rs
+++ b/vsock-proxy/shared/src/lib.rs
@@ -92,8 +92,7 @@ pub const VSOCK_PARENT_CID: u32 = 2;
 pub const VSOCK_LISTENER_CID: u32 = VSOCK_PARENT_CID;
 
 #[cfg(any(platform = "simulator", platform = "snp"))]
-// TODO(before merge): don't hardcode u32::MAX
-pub const VSOCK_LISTENER_CID: u32 = u32::MAX; // VMADDR_CID_ANY
+pub const VSOCK_LISTENER_CID: u32 = tokio_vsock::VMADDR_CID_ANY;
 
 pub fn parse_console_argument<T: NumArg>(args: &ArgMatches, name: &str) -> T {
     parse_optional_console_argument(args, name).expect(format!("{} must be specified", name).as_str())

--- a/vsock-proxy/shared/src/lib.rs
+++ b/vsock-proxy/shared/src/lib.rs
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![deny(warnings)]
 
 pub mod models;
 pub mod netlink;
@@ -79,8 +80,20 @@ pub fn vec_to_ip6(vec: &[u16]) -> Result<Ipv6Addr, String> {
     Ok(Ipv6Addr::from(as_array))
 }
 
+#[cfg(platform = "nitro")]
 // Context identifier of the parent (https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html)
 pub const VSOCK_PARENT_CID: u32 = 3;
+
+#[cfg(any(platform = "simulator", platform = "snp"))]
+pub const VSOCK_PARENT_CID: u32 = 2;
+
+#[cfg(platform = "nitro")]
+// Context identifier of the parent (https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html)
+pub const VSOCK_LISTENER_CID: u32 = VSOCK_PARENT_CID;
+
+#[cfg(any(platform = "simulator", platform = "snp"))]
+// TODO(before merge): don't hardcode u32::MAX
+pub const VSOCK_LISTENER_CID: u32 = u32::MAX; // VMADDR_CID_ANY
 
 pub fn parse_console_argument<T: NumArg>(args: &ArgMatches, name: &str) -> T {
     parse_optional_console_argument(args, name).expect(format!("{} must be specified", name).as_str())


### PR DESCRIPTION
Reference changes for supporting SNP in vsock-proxy. These are incomplete right now as we need to have a consensus on things converter expects.
For testing the current version, I used some scripts to generate a temporary setup. The setup is basically a test parent image based on `parent-base-snp` that launches vsock-proxy parent, which in turn starts qemu. The qemu command is given an initramfs (based on `enclave-base-snp`). On startup of vm, it runs a vsock-proxy enclave which is given an `enclave-settings.json` pointing to a hello world app (the app is in the blockfile).
Note: I made some changes to qemu args (like policy and FMS values) after my testing. (I will update description once I have tested latest)

This is currently not ready for review - it needs some cleanup and I am not done confirming on the exact parameters used in qemu command. But feel free to add comments if any.