### PR TITLE
RTE-1012: Environmental variable for embedded-attestation-client to allow specific toolchain for attestation client build

### DIFF
--- a/embedded-attestation-client/build.rs
+++ b/embedded-attestation-client/build.rs
@@ -59,8 +59,13 @@ fn main() {
     }
     let attest_client_dir = roche_dir.join("product-packages/services/malbork/attestation-client");
 
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_NAME");
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_PATH");
+    for env_var in [
+        "EMBED_ATTEST_CLIENT_ROCHE_NAME",
+        "EMBED_ATTEST_CLIENT_ROCHE_PATH",
+        "EMBED_ATTEST_CLIENT_ROCHE_TOOLCHAIN",
+    ] {
+        println!("cargo::rerun-if-env-changed={}", env_var);
+    }
 
     // Rebuild if this file has changed
     println!("cargo::rerun-if-changed=build.rs");
@@ -86,24 +91,33 @@ fn main() {
     let target_profile = env::var("PROFILE").unwrap();
     let target_dir = roche_dir.join("target").join(&target_profile);
 
-    // Get the toolchain version used in Roche, as we cannot use the Salmiac toolchain
-    let mut buf = String::new();
-    File::open(roche_dir.join("rust-toolchain.toml"))
-        .expect("Could not find rust-toolchain.toml file")
-        .read_to_string(&mut buf)
-        .expect("Failed to read rust-toolchain.toml file");
-    let table = toml::from_str::<toml::Value>(&buf).expect("Could not parse rust-toolchain.toml");
-    let toolchain = if let toml::Value::Table(table) = table {
-        if let toml::Value::Table(toolchain_table) = table.get("toolchain").unwrap() {
-            toolchain_table["channel"]
-                .as_str()
-                .expect("Could not find channel")
-                .to_string()
-        } else {
-            panic!("Could not \"toolchain\" table in rust-toolchain.toml");
-        }
+    // The toolchain can be provided by either an environmental variable, EMBED_ATTEST_CLIENT_ROCHE_TOOLCHAIN,
+    // or by the toolchain file in Roche; the latter is preferable
+    let toolchain = if let Ok(env_roche_toolchain) = env::var("EMBED_ATTEST_CLIENT_ROCHE_TOOLCHAIN")
+    {
+        env_roche_toolchain
     } else {
-        panic!("Could not get roche toolchain channel");
+        // Get the toolchain version used in Roche, as we cannot use the Salmiac toolchain
+        let mut buf = String::new();
+        File::open(roche_dir.join("rust-toolchain.toml"))
+            .expect("Could not find rust-toolchain.toml file")
+            .read_to_string(&mut buf)
+            .expect("Failed to read rust-toolchain.toml file");
+        let table =
+            toml::from_str::<toml::Value>(&buf).expect("Could not parse rust-toolchain.toml");
+        let toml_roche_toolchain = if let toml::Value::Table(table) = table {
+            if let toml::Value::Table(toolchain_table) = table.get("toolchain").unwrap() {
+                toolchain_table["channel"]
+                    .as_str()
+                    .expect("Could not find channel")
+                    .to_string()
+            } else {
+                panic!("Could not \"toolchain\" table in rust-toolchain.toml");
+            }
+        } else {
+            panic!("Could not get roche toolchain channel");
+        };
+        toml_roche_toolchain
     };
 
     // We build the real agent for SNP, otherwise make a dummy

--- a/tools/container-converter/build.rs
+++ b/tools/container-converter/build.rs
@@ -23,8 +23,13 @@ const RESOURCES_PARENT_DIR: &str = "src/resources/parent";
 const RESOURCES_ENCLAVE_DIR: &str = "src/resources/enclave";
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_NAME");
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_PATH");
+    for env_var in [
+        "EMBED_ATTEST_CLIENT_ROCHE_NAME",
+        "EMBED_ATTEST_CLIENT_ROCHE_PATH",
+        "EMBED_ATTEST_CLIENT_ROCHE_TOOLCHAIN",
+    ] {
+        println!("cargo::rerun-if-env-changed={}", env_var);
+    }
 
     for dir in &[
         PathBuf::from("../../vsock-proxy"),

--- a/vsock-proxy/enclave/build.rs
+++ b/vsock-proxy/enclave/build.rs
@@ -63,8 +63,13 @@ fn main() -> io::Result<()> {
         panic!("{}", err);
     }
 
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_NAME");
-    println!("cargo::rerun-if-env-changed=EMBED_ATTEST_CLIENT_ROCHE_PATH");
+    for env_var in [
+        "EMBED_ATTEST_CLIENT_ROCHE_NAME",
+        "EMBED_ATTEST_CLIENT_ROCHE_PATH",
+        "EMBED_ATTEST_CLIENT_ROCHE_TOOLCHAIN",
+    ] {
+        println!("cargo::rerun-if-env-changed={}", env_var);
+    }
 
     for dir in &[PathBuf::from("../../embedded-attestation-client")] {
         for entry in walkdir::WalkDir::new(dir)


### PR DESCRIPTION
This change allows a developer to use a different toolchain specification for building the attestation client as part of the embedded-attestation-client. 