### PR TITLE
[RTE-964] Use tar files as fallbacks for base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /build/
 /build-support/target
 /artifacts
-/docker/staging
+/docker/**/staging
 /tools/container-converter/target
 vsock-proxy/target
 enclave-startup/target

--- a/tools/container-converter/src/image_builder/enclave/nitro.rs
+++ b/tools/container-converter/src/image_builder/enclave/nitro.rs
@@ -176,9 +176,12 @@ impl<'a> EnclaveImageBuilder<'a> {
         Ok(nitro_measurements)
     }
 
-    pub(crate) fn get_enclave_base_image_name(
+    pub(crate) fn get_enclave_base_details(
         _enclaves_options: &NitroEnclavesConversionRequestOptions,
-    ) -> String {
-        env::var("ENCLAVE_IMAGE").unwrap_or(crate::ENCLAVE_IMAGE.to_owned())
+    ) -> (String, String) {
+        (
+            env::var("ENCLAVE_IMAGE").unwrap_or(crate::ENCLAVE_IMAGE.to_owned()),
+            crate::ENCLAVE_IMAGE_PATH.to_owned(),
+        )
     }
 }

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -46,7 +46,6 @@ impl<'a> EnclaveImageBuilder<'a> {
     ];
     pub const INITRAMFS_FILENAME: &'static str = "initramfs.gz";
     pub const OVMF_FILENAME: &'static str = "OVMF.amdsev.fd";
-    pub const ENCLAVE_BASE_FILENAME: &'static str = "enclave-base.tar";
 
     pub(crate) async fn create_image(
         &self,
@@ -122,7 +121,7 @@ impl<'a> EnclaveImageBuilder<'a> {
             })?;
         info!("Serialized enclave manifest in {:?}.", start.elapsed());
 
-        let enclave_base_tar_path = work_dir.join(Self::ENCLAVE_BASE_FILENAME);
+        let enclave_base_tar_path = work_dir.join(crate::ENCLAVE_IMAGE_PATH);
         let start = Instant::now();
         info!("Exporting enclave-base image...");
         let enclave_base_archive = self
@@ -148,16 +147,24 @@ impl<'a> EnclaveImageBuilder<'a> {
         compute_launch_measurements(&enclave_settings, &initramfs_file_path).await
     }
 
-    pub(crate) fn get_enclave_base_image_name(
+    pub(crate) fn get_enclave_base_details(
         enclaves_options: &SNPEnclavesConversionRequestOptions,
-    ) -> String {
-        env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
-            if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
-                crate::ENCLAVE_IMAGE_SNP_GPU.to_owned()
-            } else {
-                crate::ENCLAVE_IMAGE.to_owned()
-            }
-        })
+    ) -> (String, String) {
+        env::var("ENCLAVE_IMAGE")
+            .map(|img| (img, crate::ENCLAVE_IMAGE_PATH.to_owned()))
+            .unwrap_or_else(|_| {
+                if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
+                    (
+                        crate::ENCLAVE_IMAGE_SNP_GPU.to_owned(),
+                        crate::ENCLAVE_GPU_IMAGE_PATH.to_owned(),
+                    )
+                } else {
+                    (
+                        crate::ENCLAVE_IMAGE.to_owned(),
+                        crate::ENCLAVE_IMAGE_PATH.to_owned(),
+                    )
+                }
+            })
     }
 }
 

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -113,6 +113,7 @@ const ENCLAVE_IMAGE_SNP_GPU: &str = "enclave-base-snp-gpu";
 
 const ENCLAVE_IMAGE_PATH: &str = "enclave-base.tar";
 
+#[cfg(platform = "snp")]
 const ENCLAVE_GPU_IMAGE_PATH: &str = "enclave-base-gpu.tar";
 
 const DEFAULT_RSA_SIZE: u32 = 3072;
@@ -196,12 +197,14 @@ async fn run0(
 
     info!("Building enclave image!");
     let image_result = {
-        let enclave_base_image_str = PlatformEnclaveImageBuilder::get_enclave_base_image_name(
-            &conversion_request.enclaves_options,
-        );
+        let (enclave_base_image_str, enclave_base_image_path_str) =
+            PlatformEnclaveImageBuilder::get_enclave_base_details(
+                &conversion_request.enclaves_options,
+            );
         info!("Enclave base image is {}", enclave_base_image_str);
 
-        let enclave_base_image = get_enclave_base_image(&enclave_base_image_str).await?;
+        let enclave_base_image =
+            get_enclave_base_image(&enclave_base_image_str, enclave_base_image_path_str).await?;
 
         let user_program_config = create_user_program_config(
             &conversion_request.request.converter_options,
@@ -391,11 +394,11 @@ fn hex_response(arg: &str) -> Result<HexString> {
     })
 }
 
-async fn get_enclave_base_image(image: &str) -> Result<ImageWithDetails<'_>> {
+async fn get_enclave_base_image(image: &str, image_path: String) -> Result<ImageWithDetails<'_>> {
     let username = env_var_or_none("ENCLAVE_IMAGE_USERNAME");
     let password = env_var_or_none("ENCLAVE_IMAGE_PASSWORD");
 
-    get_base_image(&image, ENCLAVE_IMAGE_PATH.to_owned(), username, password).await
+    get_base_image(&image, image_path, username, password).await
 }
 
 async fn get_parent_base_image(image: &str) -> Result<()> {

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -80,6 +80,7 @@ pub enum ConverterErrorKind {
     BadCertConfig,
     BadCcmConfiguration,
     BadDsmConfiguration,
+    DockerLoad,
 }
 
 impl fmt::Display for ConverterError {
@@ -91,13 +92,15 @@ impl fmt::Display for ConverterError {
 impl Error for ConverterError {}
 
 #[cfg(platform = "nitro")]
-const PARENT_IMAGE: &str = "parent-base";
+const PARENT_IMAGE: &str = "parent-base-nitro";
 
 #[cfg(platform = "snp")]
 const PARENT_IMAGE: &str = "parent-base-snp";
 
 #[cfg(platform = "simulator")]
 const PARENT_IMAGE: &str = "parent-base-simulator";
+
+const PARENT_IMAGE_PATH: &str = "parent-base.tar";
 
 #[cfg(any(platform = "nitro", platform = "snp"))]
 const ENCLAVE_IMAGE: &str = "enclave-base";
@@ -107,6 +110,10 @@ const ENCLAVE_IMAGE: &str = "enclave-base-simulator";
 
 #[cfg(platform = "snp")]
 const ENCLAVE_IMAGE_SNP_GPU: &str = "enclave-base-snp-gpu";
+
+const ENCLAVE_IMAGE_PATH: &str = "enclave-base.tar";
+
+const ENCLAVE_GPU_IMAGE_PATH: &str = "enclave-base-gpu.tar";
 
 const DEFAULT_RSA_SIZE: u32 = 3072;
 const RSA_KEY_SIZES: [u32; 3] = [2048, DEFAULT_RSA_SIZE, 4096];
@@ -388,20 +395,21 @@ async fn get_enclave_base_image(image: &str) -> Result<ImageWithDetails<'_>> {
     let username = env_var_or_none("ENCLAVE_IMAGE_USERNAME");
     let password = env_var_or_none("ENCLAVE_IMAGE_PASSWORD");
 
-    get_base_image(&image, username, password).await
+    get_base_image(&image, ENCLAVE_IMAGE_PATH.to_owned(), username, password).await
 }
 
 async fn get_parent_base_image(image: &str) -> Result<()> {
     let username = env_var_or_none("PARENT_IMAGE_USERNAME");
     let password = env_var_or_none("PARENT_IMAGE_PASSWORD");
 
-    let _ = get_base_image(&image, username, password).await?;
+    let _ = get_base_image(&image, PARENT_IMAGE_PATH.to_owned(), username, password).await?;
 
     Ok(())
 }
 
 async fn get_base_image(
     image: &str,
+    base_image_tar_path: String,
     username: Option<String>,
     password: Option<String>,
 ) -> Result<ImageWithDetails<'_>> {
@@ -419,13 +427,30 @@ async fn get_base_image(
         kind: ConverterErrorKind::BadRequest,
     })?;
 
-    let details = repository
-        .get_local_image_details(&reference)
-        .await
-        .map_err(|message| ConverterError {
-            message: format!("Failed retrieving requisite {} image. {:?}", image, message),
-            kind: ConverterErrorKind::ImageGet,
-        })?;
+    let details = match repository.get_local_image_details(&reference).await {
+        Ok(details) => details,
+        Err(message) => {
+            info!(
+                "Failed retrieving requisite {} image from local repository. {:?}",
+                image, message
+            );
+            repository
+                .load_image(&base_image_tar_path)
+                .await
+                .map_err(|message| ConverterError {
+                    message: format!("Failed to load requisite {} image. {:?}", image, message),
+                    kind: ConverterErrorKind::DockerLoad,
+                })?;
+            info!("Loaded requisite from backup tar file");
+            repository
+                .get_local_image_details(&reference)
+                .await
+                .map_err(|message| ConverterError {
+                    message: format!("Failed retrieving requisite {} image. {:?}", image, message),
+                    kind: ConverterErrorKind::ImageGet,
+                })?
+        }
+    };
 
     Ok(ImageWithDetails { reference, details })
 }


### PR DESCRIPTION
This PR implements a fallback mechanism to load the image from tar file when it is not available in the local Docker repository or not set.