### PR TITLE
[RTE-1031] Update parent base image of nitro platform

### DIFF
--- a/docker/nitro/Dockerfile
+++ b/docker/nitro/Dockerfile
@@ -1,4 +1,4 @@
-FROM fortanix/parent-base-nitro:3.0.0 as nitro-cli
+FROM fortanix/parent-base-nitro:4.0.0 as nitro-cli
 
 FROM ubuntu:24.04
 
@@ -13,7 +13,6 @@ RUN apt-get update && \
 COPY --from=nitro-cli /etc/nitro_enclaves /etc/nitro_enclaves
 COPY --from=nitro-cli /usr/bin/nitro-cli /usr/bin
 COPY --from=nitro-cli /usr/bin/nitro-enclaves-allocator /usr/bin
-COPY --from=nitro-cli /usr/share/nitro_enclaves /usr/share/nitro_enclaves
 
 RUN mkdir -p /var/log/nitro_enclaves
 

--- a/docker/nitro/build-conv-container.sh
+++ b/docker/nitro/build-conv-container.sh
@@ -16,7 +16,7 @@ docker save -o ./staging/parent-base.tar parent-base-nitro
 # The Dockerfile used to build the converter uses a prebuilt parent-base
 # image by default which resides in the Fortanix Docker repository. The users
 # of this script can use the parent-base image which was built by them.
-docker tag parent-base-nitro fortanix/parent-base-nitro:3.0.0
+docker tag parent-base-nitro fortanix/parent-base-nitro:4.0.0
 
 # Build the converter
 docker build -t nitro-converter .

--- a/docker/nitro/parent-base/Dockerfile
+++ b/docker/nitro/parent-base/Dockerfile
@@ -68,8 +68,6 @@ RUN apt-get update \
 COPY --from=nitro-cli aws-nitro-enclaves-cli/install/etc/nitro_enclaves /etc/nitro_enclaves
 COPY --from=nitro-cli aws-nitro-enclaves-cli/install/usr/bin /usr/bin
 COPY --from=nitro-cli aws-nitro-enclaves-cli/install/usr/lib/systemd/system /usr/lib/systemd/system
-COPY --from=nitro-cli aws-nitro-enclaves-cli/install/usr/share /usr/share
-COPY --from=nitro-cli aws-nitro-enclaves-cli/blobs/x86_64 /usr/share/nitro_enclaves/blobs
 
 COPY dnsmasq.d /etc/dnsmasq.d
 # Setup the env for nitro-cli

--- a/run-application-tests.sh
+++ b/run-application-tests.sh
@@ -15,7 +15,7 @@ echo "AWS_CREDENTIALS=$(/usr/bin/base64 --wrap=0 < ~/.aws/credentials)" >> docke
 ECR_PASSWORD=$(aws ecr get-login-password --region us-west-1)
 echo "ECR_PASSWORD=$ECR_PASSWORD" >> docker-env
 
-PARENT_IMAGE=fortanix/parent-base-nitro:3.0.0
+PARENT_IMAGE=fortanix/parent-base-nitro:4.0.0
 echo "PARENT_IMAGE=$PARENT_IMAGE" >> docker-env
 
 ENCLAVE_IMAGE=fortanix/enclave-base:1.1.0

--- a/test/tests-container-salmiac/Dockerfile-salmiac-ub24
+++ b/test/tests-container-salmiac/Dockerfile-salmiac-ub24
@@ -1,4 +1,4 @@
-FROM fortanix/parent-base-nitro:3.0.0 as nitro-cli
+FROM fortanix/parent-base-nitro:4.0.0 as nitro-cli
 
 ARG PLATFORM
 ARG FLAVOR


### PR DESCRIPTION
- Clean up nitro blobs from nitro parent-base image. They are not used. Instead the blobs need to be built from aws-nitro-enclaves-sdk-bootstrap and packaged into the converter container. 

- Update parent-base image tag references.