### PR TITLE
Updated Release Notes for Salmiac SNP Beta release 2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,9 @@
 # Release Notes
 
-# Release version `0.45`.
-Commit: `185af18`
-
 ## SEV-SNP enclave support
+
+## Release version `0.45`.
+Commit: `185af18`
 
 ### Changed
 
@@ -11,10 +11,8 @@ Commit: `185af18`
 
 ========================
 
-# Release version `0.44`.
+## Release version `0.44`.
 Commit: `2d52d86`
-
-## SEV-SNP enclave support
 
 ### Added
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,7 @@
 # Release Notes
 
-## Version
-
 The release version is `0.45`.
+Commit: `185af18`
 
 ## SEV-SNP enclave support
 
@@ -10,9 +9,10 @@ The release version is `0.45`.
 
 - Added support for converting container images up to 500 GB in size.
 
-## Version
+================
 
 The release version is `0.44`.
+Commit: `2d52d86`
 
 ## SEV-SNP enclave support
 
@@ -20,7 +20,6 @@ The release version is `0.44`.
 
 - Added support for building Salmiac enclaves for AMD SEV-SNP.
 - Added support for GPU passthrough in SEV-SNP Salmiac enclaves.
-- Added support for converting container images up to 500 GB in size.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ The release version is `0.44`.
 
 - Added support for building Salmiac enclaves for AMD SEV-SNP.
 - Added support for GPU passthrough in SEV-SNP Salmiac enclaves.
+- Added support for converting container images up to 500 GB in size.
 
 ### Changed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-Release version `0.45`.
+# Release version `0.45`.
 Commit: `185af18`
 
 ## SEV-SNP enclave support
@@ -9,9 +9,9 @@ Commit: `185af18`
 
 - Maximum compressed image size limit for conversion is now configurable at build time.
 
-================
+========================
 
-Release version `0.44`.
+# Release version `0.44`.
 Commit: `2d52d86`
 
 ## SEV-SNP enclave support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,17 @@
 # Release Notes
 
-The release version is `0.45`.
+Release version `0.45`.
 Commit: `185af18`
 
 ## SEV-SNP enclave support
 
-### Added
+### Changed
 
 - Maximum compressed image size limit for conversion is now configurable at build time.
 
 ================
 
-The release version is `0.44`.
+Release version `0.44`.
 Commit: `2d52d86`
 
 ## SEV-SNP enclave support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,16 @@
 
 ## Version
 
+The release version is `0.45`.
+
+## SEV-SNP enclave support
+
+### Added
+
+- Added support for converting container images up to 500 GB in size.
+
+## Version
+
 The release version is `0.44`.
 
 ## SEV-SNP enclave support

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Commit: `185af18`
 
 ### Added
 
-- Added support for converting container images up to 500 GB in size.
+- Maximum compressed image size limit for conversion is now configurable at build time.
 
 ================
 


### PR DESCRIPTION
Adding the RN entry to include the size limit extension untill 500GB