### PR TITLE
[RTE-1066]: Update qemu machine parameters for tdx.

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -55,6 +55,8 @@ registered as a debug build in a test-only deployment account.
   passed to the nitro-cli run command.
 
 ##### AMD SEV-SNP enclaves settings variables
+- CPU_COUNT - Override the `-smp` param passed while running the enclave i.e.
+  passed to the qemu run command.
 - MEM_SIZE - Override the `-m` param & memory backend object passed while running
   the enclave i.e. passed to the qemu run command.
 - SNP_GPU_BDF - For use with EnclaveOS containers with GPU passthrough.

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -55,8 +55,6 @@ registered as a debug build in a test-only deployment account.
   passed to the nitro-cli run command.
 
 ##### AMD SEV-SNP enclaves settings variables
-- CPU_COUNT - Override the `-smp` param passed while running the enclave i.e.
-  passed to the qemu run command.
 - MEM_SIZE - Override the `-m` param & memory backend object passed while running
   the enclave i.e. passed to the qemu run command.
 - SNP_GPU_BDF - For use with EnclaveOS containers with GPU passthrough.

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -8,11 +8,11 @@ use std::env;
 use super::{GuestLaunchResult, GuestTasks};
 use crate::platform::qemu::QemuPlatform;
 
-const OVMF_PATH: &str = "/opt/fortanix/enclave-os/OVMF.tdx.fd";
+const OVMF_PATH: &str = "/opt/fortanix/enclave-os/OVMF.inteltdx.fd";
 const GUEST_DEV_PATH: &str = "/dev/tdx_guest";
 const MEMORY_BACKEND_ID: &str = "mem0";
 const MEMORY_SIZE: &str = "8G";
-const TDX_ID: &str = "tdx";
+const TDX_ID: &str = "tdx0";
 
 struct TdxPlatform;
 
@@ -22,7 +22,7 @@ impl TdxPlatform {
     }
 
     fn tdx_guest() -> String {
-        format!(r#"{{"qom-type":"tdx-guest","id":"{}"}}"#, TDX_ID)
+        format!("tdx-guest,id={TDX_ID}")
     }
 }
 
@@ -41,8 +41,7 @@ impl QemuPlatform for TdxPlatform {
 
     fn machine(&self) -> Option<String> {
         let machine = format!(
-            "q35,kernel_irqchip=split,confidential-guest-support={},memory-backend={}",
-            TDX_ID, MEMORY_BACKEND_ID
+            "q35,kernel_irqchip=split,confidential-guest-support={TDX_ID},memory-backend={MEMORY_BACKEND_ID},hpet=off,smm=off,pic=off",
         );
         Some(machine)
     }
@@ -86,11 +85,11 @@ mod tests {
         #[rustfmt::skip]
         let expected = vec![
             "-enable-kvm", "-nographic", "-monitor", "none", "-no-reboot",
-            "-machine", "q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=mem0",
+            "-machine", "q35,kernel_irqchip=split,confidential-guest-support=tdx0,memory-backend=mem0,hpet=off,smm=off,pic=off",
             "-cpu", "host", "-smp", "2", "-m", "8G",
             "-object", "memory-backend-ram,id=mem0,size=8G",
-            "-object", r#"{"qom-type":"tdx-guest","id":"tdx"}"#,
-            "-bios", "/opt/fortanix/enclave-os/OVMF.tdx.fd",
+            "-object", "tdx-guest,id=tdx0",
+            "-bios", "/opt/fortanix/enclave-os/OVMF.inteltdx.fd",
             "-kernel", "/opt/fortanix/enclave-os/bzImage",
             "-initrd", "/opt/fortanix/enclave-os/initramfs.gz",
             "-append", "console=ttyS0 rdinit=/init loglevel=7",

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -11,14 +11,17 @@ use crate::platform::qemu::QemuPlatform;
 const OVMF_PATH: &str = "/opt/fortanix/enclave-os/OVMF.inteltdx.fd";
 const GUEST_DEV_PATH: &str = "/dev/tdx_guest";
 const MEMORY_BACKEND_ID: &str = "mem0";
-const MEMORY_SIZE: &str = "8G";
 const TDX_ID: &str = "tdx0";
 
 struct TdxPlatform;
 
 impl TdxPlatform {
-    fn memory_backend() -> String {
-        format!("memory-backend-ram,id={MEMORY_BACKEND_ID},size={MEMORY_SIZE}")
+    fn memory_backend(&self) -> String {
+        let memory_size = self.memory_size();
+        format!(
+            "memory-backend-ram,id={},size={}",
+            MEMORY_BACKEND_ID, memory_size
+        )
     }
 
     fn tdx_guest() -> String {
@@ -47,7 +50,7 @@ impl QemuPlatform for TdxPlatform {
     }
 
     fn objects(&self) -> Vec<String> {
-        vec![Self::memory_backend(), Self::tdx_guest()]
+        vec![self.memory_backend(), Self::tdx_guest()]
     }
 
     fn gpu(&self) -> Option<String> {


### PR DESCRIPTION
Updates the qemu parameters for Tdx based on the findings from ubuntu 26 host experiments. The most important update is the one made to `-machine`. If those additional arguments in this PR are missing, tdx-measure tool's measurements mismatch.