### PR TITLE
[RTE-1001] Add tdx support converter-container.

### DIFF
--- a/api-model/src/tdx.rs
+++ b/api-model/src/tdx.rs
@@ -1,3 +1,12 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::HexString;
 use crate::{
     converter::{ConversionRequest, ConvertedImageInfo},

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /app
 COPY staging/server staging/parent-base.tar staging/enclave-base.tar /app/
 
 COPY staging/blobs/init /opt/fortanix/enclave-os/blobs/init
-COPY staging/blobs/kernel /opt/fortanix/enclave-os/blobs/kernel
+COPY staging/blobs/bzImage /opt/fortanix/enclave-os/blobs/bzImage
 
 ENTRYPOINT [ "./server" ]

--- a/docker/simulator/build-conv-container.sh
+++ b/docker/simulator/build-conv-container.sh
@@ -31,8 +31,8 @@ if [ ! -f "$artifact_dir/init" ]; then
   exit 1
 fi
 
-if [ ! -f "$artifact_dir/kernel" ]; then
-  echo "error: kernel not found at $artifact_dir/kernel"
+if [ ! -f "$artifact_dir/bzImage" ]; then
+  echo "error: bzImage not found at $artifact_dir/bzImage"
   exit 1
 fi
 
@@ -41,7 +41,7 @@ mkdir -p "$script_dir/staging/blobs"
 
 cp "$converter_bin" "$script_dir/staging/server"
 cp "$artifact_dir/init" "$script_dir/staging/blobs/init"
-cp "$artifact_dir/kernel" "$script_dir/staging/blobs/kernel"
+cp "$artifact_dir/bzImage" "$script_dir/staging/blobs/bzImage"
 
 docker save -o "$script_dir/staging/enclave-base.tar" enclave-base-simulator:latest
 docker save -o "$script_dir/staging/parent-base.tar" parent-base-simulator:latest

--- a/tools/container-converter/Cargo.toml
+++ b/tools/container-converter/Cargo.toml
@@ -15,7 +15,6 @@ clap = "2.33"
 docker-image-reference = "0.1.0"
 env_logger = "0.7"
 exitcode = "1.1.2"
-# TODO: Remove branch once https://github.com/fortanix/rust-sgx/pull/931 is merged.
 fortanix-vme-initramfs = "0.2"
 futures = "0.3"
 http = "0.2.8"

--- a/tools/container-converter/src/image_builder/blob_finder.rs
+++ b/tools/container-converter/src/image_builder/blob_finder.rs
@@ -1,0 +1,40 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::path::PathBuf;
+use crate::image_builder::INSTALLATION_DIR;
+
+const BLOBS_SUBDIR_GPU_ENABLED: &'static str = "kernel_enabled_gpu";
+const BLOBS_SUBDIR_GPU_DISABLED: &'static str = "kernel_disabled_gpu";
+
+pub(crate) struct BlobFinder;
+
+impl BlobFinder {
+    pub(crate) fn blobs_dir() -> PathBuf {
+        PathBuf::from(INSTALLATION_DIR).join("blobs")
+    }
+
+    pub(crate) fn kernel_blobs_dir(gpu_passthrough: bool) -> PathBuf {
+        let subdir = if gpu_passthrough {
+            BLOBS_SUBDIR_GPU_ENABLED
+        } else {
+            BLOBS_SUBDIR_GPU_DISABLED
+        };
+        Self::blobs_dir().join(subdir)
+    }
+
+    pub(crate) fn ovmf_path(ovmf_filename: &str) -> PathBuf {
+        Self::blobs_dir().join(ovmf_filename)
+    }
+
+    pub(crate) fn kernel_path(gpu_passthrough: bool) -> PathBuf {
+        Self::kernel_blobs_dir(gpu_passthrough).join("bzImage")
+    }
+
+    pub(crate) fn kernel_config_path(gpu_passthrough: bool) -> PathBuf {
+        Self::kernel_blobs_dir(gpu_passthrough).join("bzImage.config")
+    }
+}

--- a/tools/container-converter/src/image_builder/blob_finder.rs
+++ b/tools/container-converter/src/image_builder/blob_finder.rs
@@ -4,8 +4,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::path::PathBuf;
 use crate::image_builder::INSTALLATION_DIR;
+use std::path::PathBuf;
 
 const BLOBS_SUBDIR_GPU_ENABLED: &'static str = "kernel_enabled_gpu";
 const BLOBS_SUBDIR_GPU_DISABLED: &'static str = "kernel_disabled_gpu";

--- a/tools/container-converter/src/image_builder/enclave/initramfs.rs
+++ b/tools/container-converter/src/image_builder/enclave/initramfs.rs
@@ -20,9 +20,9 @@ use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::image_builder::INSTALLATION_DIR;
 
+use crate::image_builder::blob_finder::BlobFinder;
 #[cfg(any(platform = "snp", platform = "tdx"))]
 pub(crate) use gpu_supported::GpuSupportedInitramfsBuilder;
-use crate::image_builder::blob_finder::BlobFinder;
 
 const INIT_BIN: &str = "init";
 
@@ -33,7 +33,6 @@ pub(crate) trait InitramfsBuilder {
         blobs_dir: &Path,
         enclave_settings: &EnclaveSettings,
     ) -> StdResult<FsTree, IoError>;
-
 
     fn read_init(blobs_dir: &Path) -> StdResult<Vec<u8>, IoError> {
         let init_path = blobs_dir.join(INIT_BIN);
@@ -121,11 +120,11 @@ mod gpu_supported {
     use super::*;
 
     pub(crate) struct GpuSupportedInitramfsBuilder;
- 
-     impl InitramfsBuilder for GpuSupportedInitramfsBuilder {
-         fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf {
-             BlobFinder::kernel_blobs_dir(enclave_settings.gpu_passthrough)
-         }
+
+    impl InitramfsBuilder for GpuSupportedInitramfsBuilder {
+        fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf {
+            BlobFinder::kernel_blobs_dir(enclave_settings.gpu_passthrough)
+        }
 
         // Adds nvidia kernel modules and firmwares
         // if gpu passthrough is enabled.
@@ -219,7 +218,7 @@ pub(crate) struct BasicInitramfsBuilder;
 #[cfg(platform = "simulator")]
 impl InitramfsBuilder for BasicInitramfsBuilder {
     fn kernel_blobs_dir(_enclave_settings: &EnclaveSettings) -> PathBuf {
-        Self::blobs_dir()
+        BlobFinder::blobs_dir()
     }
 
     fn add_kernel_modules(

--- a/tools/container-converter/src/image_builder/enclave/initramfs.rs
+++ b/tools/container-converter/src/image_builder/enclave/initramfs.rs
@@ -1,0 +1,361 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use log::{info, warn};
+use std::fs;
+use std::io::{Cursor, Error as IoError, ErrorKind as IoErrorKind, Read};
+use std::path::{Path, PathBuf};
+use std::result::Result as StdResult;
+use std::time::Instant;
+
+use fortanix_vme_initramfs::{FsTree, Initramfs};
+use nix::sys::stat::SFlag;
+use tar::{Archive, EntryType};
+
+use crate::image_builder::enclave::qemu::DEFAULT_PATH;
+use crate::image_builder::enclave::EnclaveSettings;
+use crate::image_builder::enclave::GenericEnclaveImageBuilder;
+use crate::image_builder::INSTALLATION_DIR;
+
+#[cfg(any(platform = "snp", platform = "tdx"))]
+pub(crate) use gpu_supported::GpuSupportedInitramfsBuilder;
+
+const INIT_BIN: &str = "init";
+
+pub(crate) trait InitramfsBuilder {
+    fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf;
+    fn add_kernel_modules(
+        fs_tree: FsTree,
+        blobs_dir: &Path,
+        enclave_settings: &EnclaveSettings,
+    ) -> StdResult<FsTree, IoError>;
+
+    fn blobs_dir() -> PathBuf {
+        PathBuf::from(INSTALLATION_DIR).join("blobs")
+    }
+
+    fn read_init(blobs_dir: &Path) -> StdResult<Vec<u8>, IoError> {
+        let init_path = blobs_dir.join(INIT_BIN);
+        fs::read(&init_path)
+    }
+
+    fn add_basic_fs(
+        mut fs_tree: FsTree,
+        blobs_dir: &Path,
+        enclave_settings: &EnclaveSettings,
+    ) -> StdResult<FsTree, IoError> {
+        let run_cmd = get_run_cmd(&enclave_settings);
+        let init = Self::read_init(blobs_dir)?;
+        fs_tree = fs_tree
+            .add_file("env", Cursor::new(get_env_vars(&enclave_settings.env_vars)))
+            .add_file("cmd", Cursor::new(run_cmd))
+            .add_executable("init", Cursor::new(init));
+        Ok(fs_tree)
+    }
+
+    fn add_resources(mut fs_tree: FsTree, enclave_manifest: &[u8]) -> StdResult<FsTree, IoError> {
+        let rootfs_installation_dir = PathBuf::from(format!("rootfs{}", INSTALLATION_DIR));
+
+        // Add dependencies available as resource
+        for resource in GenericEnclaveImageBuilder::IMAGE_BUILD_DEPENDENCIES {
+            let path = rootfs_installation_dir.join(resource.name);
+            let data = Cursor::new(resource.data);
+            fs_tree = if resource.is_executable {
+                fs_tree.add_executable(&path, data)
+            } else {
+                fs_tree.add_file(&path, data)
+            };
+        }
+
+        // Add enclave-settings.json generated at runtime.
+        fs_tree = fs_tree.add_file(
+            rootfs_installation_dir.join(GenericEnclaveImageBuilder::DEFAULT_ENCLAVE_SETTINGS_FILE),
+            Cursor::new(enclave_manifest.to_vec()),
+        );
+
+        Ok(fs_tree)
+    }
+
+    fn build(
+        output: &Path,
+        enclave_settings: &EnclaveSettings,
+        mut enclave_base_archive: Archive<fs::File>,
+        enclave_manifest: &[u8],
+    ) -> StdResult<(), IoError> {
+        let kernel_blobs_dir = Self::kernel_blobs_dir(enclave_settings);
+
+        let mut fs_tree = Self::add_basic_fs(FsTree::new(), &kernel_blobs_dir, enclave_settings)?;
+        fs_tree = add_enclave_base_to_initramfs(fs_tree, &mut enclave_base_archive)?;
+        fs_tree = Self::add_resources(fs_tree, enclave_manifest)?;
+        fs_tree = Self::add_kernel_modules(fs_tree, &kernel_blobs_dir, enclave_settings)?;
+
+        let start = Instant::now();
+
+        info!("Building initramfs, it may take a while depending on size of it...");
+        let output_file = fs::File::create(output)?;
+        Initramfs::from_fs_tree(fs_tree, output_file).map_err(|e| {
+            IoError::new(
+                IoErrorKind::Other,
+                format!("failed to build initramfs: {:?}", e),
+            )
+        })?;
+
+        info!(
+            "Built initramfs at {} in {:?}",
+            output.display(),
+            start.elapsed()
+        );
+        Ok(())
+    }
+}
+
+#[cfg(any(platform = "snp", platform = "tdx"))]
+mod gpu_supported {
+    /// Some fields of enclave_settings are platform-specific.
+    /// To avoid compilation errors for platforms without these fields,
+    /// the types and implementation are put in a separate module
+    /// and only enabled for the correct platform.
+    use crate::image_builder::enclave::nvidia;
+
+    use super::*;
+
+    const BLOBS_SUBDIR_GPU_ENABLED: &str = "kernel_enabled_gpu";
+    const BLOBS_SUBDIR_GPU_DISABLED: &str = "kernel_disabled_gpu";
+
+    pub(crate) struct GpuSupportedInitramfsBuilder;
+
+    impl InitramfsBuilder for GpuSupportedInitramfsBuilder {
+        fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf {
+            let blobs_dir = Self::blobs_dir();
+            let subdir = if enclave_settings.gpu_passthrough {
+                BLOBS_SUBDIR_GPU_ENABLED
+            } else {
+                BLOBS_SUBDIR_GPU_DISABLED
+            };
+            blobs_dir.join(subdir)
+        }
+
+        // Adds nvidia kernel modules and firmwares
+        // if gpu passthrough is enabled.
+        fn add_kernel_modules(
+            mut fs_tree: FsTree,
+            blobs_dir: &Path,
+            enclave_settings: &EnclaveSettings,
+        ) -> StdResult<FsTree, IoError> {
+            if enclave_settings.gpu_passthrough {
+                info!("Adding gpu modules to initramfs...");
+                let initramfs_module_path = Path::new("lib/modules");
+
+                for module in nvidia::KERNEL_MODULES {
+                    let module_path = blobs_dir.join(module);
+                    let module_data = fs::read(module_path)?;
+
+                    // Add gpu drivers to initramfs root as they are loaded by init
+                    fs_tree = fs_tree
+                        .add_file(initramfs_module_path.join(module), Cursor::new(module_data));
+                }
+
+                info!("Adding NVIDIA GSP firmware to initramfs...");
+                fs_tree = add_nvidia_firmware_to_initramfs(fs_tree)?;
+            }
+
+            Ok(fs_tree)
+        }
+    }
+
+    fn add_nvidia_firmware_to_initramfs(fs_tree: FsTree) -> std::result::Result<FsTree, IoError> {
+        let firmware_root = Path::new(nvidia::NVIDIA_DRIVER_FIRMWARE_PAYLOAD_ROOT);
+        if !firmware_root.exists() {
+            return Err(IoError::new(
+                IoErrorKind::NotFound,
+                format!(
+                    "NVIDIA firmware payload root {} does not exist in the converter image",
+                    firmware_root.display()
+                ),
+            ));
+        }
+
+        add_nvidia_firmware_dir_to_initramfs(fs_tree, firmware_root, firmware_root)
+    }
+
+    fn add_nvidia_firmware_dir_to_initramfs(
+        mut fs_tree: FsTree,
+        root: &Path,
+        dir: &Path,
+    ) -> std::result::Result<FsTree, IoError> {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            let relative_path = path.strip_prefix(root).map_err(|err| {
+                IoError::new(
+                    IoErrorKind::Other,
+                    format!(
+                        "failed to make NVIDIA firmware path {} relative to {}. {:?}",
+                        path.display(),
+                        root.display(),
+                        err
+                    ),
+                )
+            })?;
+            let relative_path = relative_path.to_str().ok_or(IoError::new(
+                IoErrorKind::Other,
+                format!("invalid NVIDIA firmware path: {}", path.display()),
+            ))?;
+
+            if file_type.is_dir() {
+                fs_tree = fs_tree.add_directory(relative_path);
+                fs_tree = add_nvidia_firmware_dir_to_initramfs(fs_tree, root, &path)?;
+            } else if file_type.is_file() {
+                let data = fs::read(&path)?;
+                fs_tree = fs_tree.add_file(relative_path, Cursor::new(data));
+            } else {
+                warn!(
+                    "Skipping unsupported NVIDIA firmware entry {}",
+                    path.display()
+                );
+            }
+        }
+
+        Ok(fs_tree)
+    }
+}
+
+#[cfg(platform = "simulator")]
+pub(crate) struct BasicInitramfsBuilder;
+
+#[cfg(platform = "simulator")]
+impl InitramfsBuilder for BasicInitramfsBuilder {
+    fn kernel_blobs_dir(_enclave_settings: &EnclaveSettings) -> PathBuf {
+        Self::blobs_dir()
+    }
+
+    fn add_kernel_modules(
+        fs_tree: FsTree,
+        _blobs_dir: &Path,
+        _enclave_settings: &EnclaveSettings,
+    ) -> StdResult<FsTree, IoError> {
+        Ok(fs_tree)
+    }
+}
+
+fn add_enclave_base_to_initramfs(
+    mut fs_tree: FsTree,
+    enclave_base_archive: &mut tar::Archive<fs::File>,
+) -> std::result::Result<FsTree, IoError> {
+    let start = Instant::now();
+    let mut entries_count = 0u64;
+    let mut files_count = 0u64;
+    let mut directories_count = 0u64;
+    let mut links_count = 0u64;
+    let mut bytes_read = 0u64;
+    let mut last_logged_bytes = 0u64;
+
+    let entries = enclave_base_archive.entries()?;
+    for entry in entries {
+        let mut entry = entry?;
+        entries_count += 1;
+
+        let path = entry.path()?;
+        let target_path = Path::new("rootfs").join(&path);
+
+        let header = entry.header();
+        // Some tar archives doesn't preserve modes.
+        let mut mode = header.mode()?;
+
+        // Tar entries do not contains file type bits of mode, instead
+        // only contains permissions part. Here, we re-set the file type
+        // related bits.
+        let file_type = match header.entry_type() {
+            EntryType::Regular | EntryType::Continuous => SFlag::S_IFREG,
+            EntryType::Directory => SFlag::S_IFDIR,
+            EntryType::Symlink => SFlag::S_IFLNK,
+            EntryType::Link => {
+                warn!(
+                    "Hard link detected: {}, hard links are treated as symbolic links...",
+                    path.display(),
+                );
+                SFlag::S_IFLNK
+            }
+            rest => {
+                warn!(
+                    "Unsupported tar entry type: {:?}, file: {}",
+                    rest,
+                    path.display()
+                );
+                return Err(IoError::new(
+                    IoErrorKind::Other,
+                    format!("unsupported tar entry: {}", path.display()),
+                ));
+            }
+        };
+        mode |= file_type.bits() as u32;
+
+        let entry_type = header.entry_type();
+        fs_tree = if entry_type.is_dir() {
+            directories_count += 1;
+            fs_tree.add_directory_with_permissions(&target_path, mode)
+        } else if entry_type.is_symlink() || entry_type.is_hard_link() {
+            // TODO: For now we're treating a hardlink as an softlink.
+            // Hard link support is to be added to the fortanix-vme-initramfs.
+            links_count += 1;
+            let link_target = entry
+                .link_name()?
+                .ok_or(IoError::new(IoErrorKind::Other, "missing link target"))?;
+            fs_tree.add_symlink_with_permissions(&target_path, link_target, mode)
+        } else {
+            files_count += 1;
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data)?;
+            bytes_read += data.len() as u64;
+            fs_tree.add_file_with_permissions(&target_path, Cursor::new(data), mode)
+        };
+
+        if entries_count % 1000 == 0
+            || bytes_read.saturating_sub(last_logged_bytes) >= 256 * 1024 * 1024
+        {
+            info!(
+                "Adding enclave-base to initramfs: entries={}, files={}, directories={}, links={}, bytes_read={} MiB, elapsed={:?}, latest={}",
+                entries_count,
+                files_count,
+                directories_count,
+                links_count,
+                bytes_read / 1024 / 1024,
+                start.elapsed(),
+                target_path.display(),
+            );
+            last_logged_bytes = bytes_read;
+        }
+    }
+
+    info!(
+        "Added enclave-base to initramfs: entries={}, files={}, directories={}, links={}, bytes_read={} MiB, elapsed={:?}",
+        entries_count,
+        files_count,
+        directories_count,
+        links_count,
+        bytes_read / 1024 / 1024,
+        start.elapsed()
+    );
+
+    Ok(fs_tree)
+}
+
+pub(crate) fn get_env_vars(enclave_env_vars: &Vec<String>) -> String {
+    let mut env_vars = enclave_env_vars.clone();
+    env_vars.push(format!("PATH={DEFAULT_PATH}"));
+    env_vars.join("\n")
+}
+
+pub(crate) fn get_run_cmd(enclave_settings: &EnclaveSettings) -> String {
+    let run_cmd = GenericEnclaveImageBuilder::enclave_command_string(
+        enclave_settings,
+        &Path::new(INSTALLATION_DIR),
+        "enclave",
+    );
+
+    format!("/bin/sh\n-c\n{}", run_cmd)
+}

--- a/tools/container-converter/src/image_builder/enclave/initramfs.rs
+++ b/tools/container-converter/src/image_builder/enclave/initramfs.rs
@@ -287,7 +287,7 @@ fn add_enclave_base_to_initramfs(
             directories_count += 1;
             fs_tree.add_directory_with_permissions(&target_path, mode)
         } else if entry_type.is_symlink() || entry_type.is_hard_link() {
-            // TODO: For now we're treating a hardlink as an softlink.
+            // TODO: For now we're treating a hardlink as a softlink.
             // Hard link support is to be added to the fortanix-vme-initramfs.
             links_count += 1;
             let link_target = entry

--- a/tools/container-converter/src/image_builder/enclave/initramfs.rs
+++ b/tools/container-converter/src/image_builder/enclave/initramfs.rs
@@ -22,6 +22,7 @@ use crate::image_builder::INSTALLATION_DIR;
 
 #[cfg(any(platform = "snp", platform = "tdx"))]
 pub(crate) use gpu_supported::GpuSupportedInitramfsBuilder;
+use crate::image_builder::blob_finder::BlobFinder;
 
 const INIT_BIN: &str = "init";
 
@@ -33,9 +34,6 @@ pub(crate) trait InitramfsBuilder {
         enclave_settings: &EnclaveSettings,
     ) -> StdResult<FsTree, IoError>;
 
-    fn blobs_dir() -> PathBuf {
-        PathBuf::from(INSTALLATION_DIR).join("blobs")
-    }
 
     fn read_init(blobs_dir: &Path) -> StdResult<Vec<u8>, IoError> {
         let init_path = blobs_dir.join(INIT_BIN);
@@ -122,21 +120,12 @@ mod gpu_supported {
 
     use super::*;
 
-    const BLOBS_SUBDIR_GPU_ENABLED: &str = "kernel_enabled_gpu";
-    const BLOBS_SUBDIR_GPU_DISABLED: &str = "kernel_disabled_gpu";
-
     pub(crate) struct GpuSupportedInitramfsBuilder;
-
-    impl InitramfsBuilder for GpuSupportedInitramfsBuilder {
-        fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf {
-            let blobs_dir = Self::blobs_dir();
-            let subdir = if enclave_settings.gpu_passthrough {
-                BLOBS_SUBDIR_GPU_ENABLED
-            } else {
-                BLOBS_SUBDIR_GPU_DISABLED
-            };
-            blobs_dir.join(subdir)
-        }
+ 
+     impl InitramfsBuilder for GpuSupportedInitramfsBuilder {
+         fn kernel_blobs_dir(enclave_settings: &EnclaveSettings) -> PathBuf {
+             BlobFinder::kernel_blobs_dir(enclave_settings.gpu_passthrough)
+         }
 
         // Adds nvidia kernel modules and firmwares
         // if gpu passthrough is enabled.

--- a/tools/container-converter/src/image_builder/enclave/mod.rs
+++ b/tools/container-converter/src/image_builder/enclave/mod.rs
@@ -16,10 +16,22 @@ pub(crate) use self::snp::EnclaveImageBuilder as PlatformEnclaveImageBuilder;
 #[cfg(platform = "snp")]
 pub(crate) mod snp_measurement;
 
+#[cfg(platform = "tdx")]
+pub(crate) mod tdx;
+#[cfg(platform = "tdx")]
+pub(crate) use self::tdx::EnclaveImageBuilder as PlatformEnclaveImageBuilder;
+
 #[cfg(platform = "simulator")]
 pub(crate) mod simulator;
 #[cfg(platform = "simulator")]
 pub(crate) use self::simulator::EnclaveImageBuilder as PlatformEnclaveImageBuilder;
+
+#[cfg(any(platform = "snp", platform = "tdx", platform = "simulator"))]
+pub(crate) mod initramfs;
+#[cfg(any(platform = "snp", platform = "tdx"))]
+pub(crate) mod nvidia;
+#[cfg(any(platform = "snp", platform = "tdx", platform = "simulator"))]
+pub(crate) mod qemu;
 
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -34,9 +46,11 @@ use api_model::converter::{CertificateConfig, ConverterOptions, DsmConfiguration
 #[cfg(platform = "nitro")]
 use api_model::enclave::EnclaveManifest;
 use api_model::enclave::{CcmBackendUrl, FileSystemConfig, UserConfig};
-#[cfg(any(platform = "snp", platform = "tdx"))]
-use api_model::NvidiaDriverCapability;
 #[cfg(platform = "snp")]
+use api_model::snp::NvidiaDriverCapability;
+#[cfg(platform = "tdx")]
+use api_model::tdx::NvidiaDriverCapability;
+#[cfg(any(platform = "snp", platform = "tdx"))]
 use api_model::EnclavesOptions;
 use docker_image_reference::Reference as DockerReference;
 use log::{debug, info, warn};
@@ -98,10 +112,10 @@ pub(crate) struct EnclaveSettings {
 
     pub(crate) dsm_configuration: DsmConfiguration,
 
-    #[cfg(platform = "snp")]
+    #[cfg(any(platform = "snp", platform = "tdx"))]
     pub(crate) gpu_passthrough: bool,
 
-    #[cfg(platform = "snp")]
+    #[cfg(any(platform = "snp", platform = "tdx"))]
     pub(crate) nvidia_driver_capabilities: Vec<String>,
 }
 
@@ -109,7 +123,7 @@ impl EnclaveSettings {
     pub(crate) fn new(
         input_image: &ImageWithDetails<'_>,
         converter_options: &ConverterOptions,
-        #[cfg(platform = "snp")] enclaves_options: &EnclavesOptions,
+        #[cfg(any(platform = "snp", platform = "tdx"))] enclaves_options: &EnclavesOptions,
     ) -> Self {
         EnclaveSettings {
             user_name: input_image.details.config.user.clone().unwrap_or_default(),
@@ -131,9 +145,9 @@ impl EnclaveSettings {
                 .dsm_configuration
                 .clone()
                 .unwrap_or_default(),
-            #[cfg(platform = "snp")]
+            #[cfg(any(platform = "snp", platform = "tdx"))]
             gpu_passthrough: enclaves_options.enable_gpu_passthrough.unwrap_or(false),
-            #[cfg(platform = "snp")]
+            #[cfg(any(platform = "snp", platform = "tdx"))]
             nvidia_driver_capabilities: {
                 if enclaves_options.enable_gpu_passthrough.unwrap_or(false) {
                     enclaves_options
@@ -199,7 +213,7 @@ impl<'a> GenericEnclaveImageBuilder<'a> {
             .await
     }
 
-    #[cfg(platform = "snp")]
+    #[cfg(any(platform = "snp", platform = "tdx", platform = "simulator"))]
     pub(crate) async fn export_enclave_base_file_system(
         &self,
         docker_util: &dyn DockerUtil,
@@ -283,7 +297,7 @@ impl<'a> GenericEnclaveImageBuilder<'a> {
             .await
     }
 
-    #[cfg(platform = "snp")]
+    #[cfg(any(platform = "snp", platform = "tdx"))]
     pub(crate) async fn create_block_file_with_nvidia_driver_payload(
         &self,
         docker_util: &dyn DockerUtil,

--- a/tools/container-converter/src/image_builder/enclave/mod.rs
+++ b/tools/container-converter/src/image_builder/enclave/mod.rs
@@ -47,9 +47,9 @@ use api_model::converter::{CertificateConfig, ConverterOptions, DsmConfiguration
 use api_model::enclave::EnclaveManifest;
 use api_model::enclave::{CcmBackendUrl, FileSystemConfig, UserConfig};
 #[cfg(any(platform = "snp", platform = "tdx"))]
-use api_model::NvidiaDriverCapability;
-#[cfg(any(platform = "snp", platform = "tdx"))]
 use api_model::EnclavesOptions;
+#[cfg(any(platform = "snp", platform = "tdx"))]
+use api_model::NvidiaDriverCapability;
 use docker_image_reference::Reference as DockerReference;
 use log::{debug, info, warn};
 use nix::sys::statfs::statfs;

--- a/tools/container-converter/src/image_builder/enclave/mod.rs
+++ b/tools/container-converter/src/image_builder/enclave/mod.rs
@@ -46,10 +46,8 @@ use api_model::converter::{CertificateConfig, ConverterOptions, DsmConfiguration
 #[cfg(platform = "nitro")]
 use api_model::enclave::EnclaveManifest;
 use api_model::enclave::{CcmBackendUrl, FileSystemConfig, UserConfig};
-#[cfg(platform = "snp")]
-use api_model::snp::NvidiaDriverCapability;
-#[cfg(platform = "tdx")]
-use api_model::tdx::NvidiaDriverCapability;
+#[cfg(any(platform = "snp", platform = "tdx"))]
+use api_model::NvidiaDriverCapability;
 #[cfg(any(platform = "snp", platform = "tdx"))]
 use api_model::EnclavesOptions;
 use docker_image_reference::Reference as DockerReference;

--- a/tools/container-converter/src/image_builder/enclave/nvidia.rs
+++ b/tools/container-converter/src/image_builder/enclave/nvidia.rs
@@ -1,0 +1,70 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+use crate::image_builder::enclave::qemu::DEFAULT_PATH;
+
+pub(crate) const NVIDIA_DRIVER_LIBRARY_PATH: &str = "/opt/fortanix/nvidia-driver/lib";
+pub(crate) const NVIDIA_DRIVER_BINARY_PATH: &str = "/opt/fortanix/nvidia-driver/bin";
+pub(crate) const NVIDIA_DRIVER_FIRMWARE_PAYLOAD_ROOT: &str =
+    "/opt/fortanix/enclave-os/nvidia-driver-payload/firmware";
+
+pub(crate) const KERNEL_MODULES: &[&str] = &[
+    "nvidia.ko",
+    "nvidia-uvm.ko",
+    "nvidia-drm.ko",
+    "nvidia-modeset.ko",
+];
+
+pub(crate) fn insert_nvidia_env_vars(
+    env_vars: &mut Vec<String>,
+    driver_capabilities: &Vec<String>,
+) {
+    prepend_env(
+        env_vars,
+        "LD_LIBRARY_PATH",
+        NVIDIA_DRIVER_LIBRARY_PATH,
+        None,
+    );
+    prepend_env(
+        env_vars,
+        "PATH",
+        NVIDIA_DRIVER_BINARY_PATH,
+        Some(DEFAULT_PATH),
+    );
+    upsert_env(
+        env_vars,
+        "NVIDIA_DRIVER_CAPABILITIES",
+        &driver_capabilities.join(","),
+    );
+}
+
+fn prepend_env(env_vars: &mut Vec<String>, key: &str, prefix: &str, default: Option<&str>) {
+    let current = get_last_env_value(env_vars, key)
+        .or_else(|| default.map(|value| value.to_string()))
+        .unwrap_or_default();
+
+    let value = if current.is_empty() {
+        prefix.to_string()
+    } else if current.split(':').any(|entry| entry == prefix) {
+        current
+    } else {
+        format!("{}:{}", prefix, current)
+    };
+
+    upsert_env(env_vars, key, &value);
+}
+
+fn get_last_env_value(env_vars: &[String], key: &str) -> Option<String> {
+    let prefix = format!("{}=", key);
+
+    env_vars
+        .iter()
+        .rev()
+        .find_map(|env| env.strip_prefix(&prefix).map(|value| value.to_string()))
+}
+
+fn upsert_env(env_vars: &mut Vec<String>, key: &str, value: &str) {
+    env_vars.push(format!("{}={}", key, value));
+}

--- a/tools/container-converter/src/image_builder/enclave/qemu.rs
+++ b/tools/container-converter/src/image_builder/enclave/qemu.rs
@@ -1,0 +1,120 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use log::info;
+use std::path::Path;
+use std::time::Instant;
+
+use api_model::enclave::{EnclaveManifest, FileSystemConfig, UserConfig};
+use async_trait::async_trait;
+
+use crate::image_builder::enclave::initramfs::InitramfsBuilder;
+use crate::image_builder::enclave::EnclaveSettings;
+use crate::image_builder::enclave::GenericEnclaveImageBuilder;
+use crate::DockerUtil;
+use crate::{ConverterError, ConverterErrorKind, Result};
+
+pub(crate) const DEFAULT_PATH: &str =
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+#[async_trait]
+pub(crate) trait QemuEnclaveImageBuilder<'a> {
+    type Measurements;
+    type InitramfsBuilder: InitramfsBuilder;
+
+    fn enclave_image_builder(&self) -> &GenericEnclaveImageBuilder<'a>;
+    #[cfg_attr(platform = "simulator", allow(unused))]
+    fn ovmf_filename(&self) -> &'static str;
+    fn initramfs_filename(&self) -> &'static str;
+    async fn create_block_file(
+        &self,
+        docker_util: &dyn DockerUtil,
+        user_config: &UserConfig,
+        enclave_settings: &EnclaveSettings,
+    ) -> Result<FileSystemConfig>;
+
+    // Function to update/override env variables passed to enclave manifest file
+    fn update_env_vars(&self, _enclave_settings: &EnclaveSettings, _env_vars: &mut Vec<String>) {}
+
+    async fn compute_launch_measurements(
+        &self,
+        enclave_settings: &EnclaveSettings,
+        initramfs_file_path: &Path,
+    ) -> Result<Self::Measurements>;
+
+    async fn create_image(
+        &self,
+        docker_util: &dyn DockerUtil,
+        enclave_settings: EnclaveSettings,
+        user_config: UserConfig,
+        mut env_vars: Vec<String>,
+        _sender: std::sync::mpsc::Sender<crate::image::ImageToClean>,
+    ) -> Result<Self::Measurements> {
+        let work_dir = self.enclave_image_builder().dir.path();
+
+        let start = Instant::now();
+        info!("Creating client FS block file...");
+        let file_system_config = self
+            .create_block_file(docker_util, &user_config, &enclave_settings)
+            .await?;
+        info!(
+            "Client FS block file has been created in {:?}.",
+            start.elapsed()
+        );
+
+        let start = Instant::now();
+        let is_debug = enclave_settings.is_debug;
+        let enable_overlay_filesystem_persistence =
+            enclave_settings.enable_overlay_filesystem_persistence;
+        let ccm_backend_url = enclave_settings.ccm_backend_url.clone();
+        let dsm_configuration = enclave_settings.dsm_configuration.clone();
+
+        self.update_env_vars(&enclave_settings, &mut env_vars);
+
+        let enclave_manifest = EnclaveManifest {
+            user_config,
+            file_system_config,
+            is_debug,
+            env_vars,
+            enable_overlay_filesystem_persistence,
+            ccm_backend_url,
+            dsm_configuration,
+        };
+
+        let enclave_manifest_data =
+            serde_json::to_vec(&enclave_manifest).map_err(|err| ConverterError {
+                message: format!("Failed serializing enclave settings file. {:?}", err),
+                kind: ConverterErrorKind::RequisitesCreation,
+            })?;
+        info!("Serialized enclave manifest in {:?}.", start.elapsed());
+
+        let enclave_base_tar_path = work_dir.join(crate::ENCLAVE_IMAGE_PATH);
+        let start = Instant::now();
+        info!("Exporting enclave-base image...");
+        let enclave_base_archive = self
+            .enclave_image_builder()
+            .export_enclave_base_file_system(docker_util, &enclave_base_tar_path)
+            .await?;
+        info!("Exported enclave-base image in {:?}.", start.elapsed());
+
+        let initramfs_file_path = work_dir.join(self.initramfs_filename());
+
+        info!("Creating initramfs archive...");
+        Self::InitramfsBuilder::build(
+            &initramfs_file_path,
+            &enclave_settings,
+            enclave_base_archive,
+            &enclave_manifest_data,
+        )
+        .map_err(|e| ConverterError {
+            message: format!("Failed to create initramfs: {}", e),
+            kind: ConverterErrorKind::EnclaveImageCreation,
+        })?;
+
+        self.compute_launch_measurements(&enclave_settings, &initramfs_file_path)
+            .await
+    }
+}

--- a/tools/container-converter/src/image_builder/enclave/simulator.rs
+++ b/tools/container-converter/src/image_builder/enclave/simulator.rs
@@ -78,7 +78,7 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         _enclave_settings: &EnclaveSettings,
     ) -> Result<FileSystemConfig> {
         let file_system_config = self
-            .enclave_image_builder()
+            .enclave_image_builder
             .create_block_file(docker_util, &user_config)
             .await?;
         Ok(file_system_config)

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -4,46 +4,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::io::{Cursor, Error as IoError, ErrorKind as IoErrorKind, Read};
-use std::path::{Path, PathBuf};
-use std::time::Instant;
-use std::{env, fs};
+use std::env;
+use std::path::Path;
 
-use api_model::enclave::{EnclaveManifest, UserConfig};
+use api_model::enclave::{FileSystemConfig, UserConfig};
 use api_model::snp::{SNPEnclavesConversionRequestOptions, SNPEnclavesMeasurements};
-use fortanix_vme_initramfs::{FsTree, Initramfs};
-use log::{info, warn};
-use nix::sys::stat::SFlag;
-use tar::{Archive, EntryType};
 
+use crate::image_builder::enclave::initramfs::{GpuSupportedInitramfsBuilder, InitramfsBuilder};
+use crate::image_builder::enclave::nvidia::insert_nvidia_env_vars;
+use crate::image_builder::enclave::qemu::QemuEnclaveImageBuilder;
 use crate::image_builder::enclave::snp_measurement::{
     compute_snp_launch_measurement, SnpMeasurementInputs,
 };
 use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
-use crate::image_builder::parent::snp::{BLOBS_SUBDIR_GPU_DISABLED, BLOBS_SUBDIR_GPU_ENABLED};
-use crate::image_builder::INSTALLATION_DIR;
 use crate::DockerUtil;
-use crate::{ConverterError, ConverterErrorKind, Result};
-
-const NVIDIA_DRIVER_LIBRARY_PATH: &str = "/opt/fortanix/nvidia-driver/lib";
-const NVIDIA_DRIVER_BINARY_PATH: &str = "/opt/fortanix/nvidia-driver/bin";
-const NVIDIA_DRIVER_FIRMWARE_PAYLOAD_ROOT: &str =
-    "/opt/fortanix/enclave-os/nvidia-driver-payload/firmware";
-const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+use crate::Result;
 
 pub(crate) struct EnclaveImageBuilder<'a> {
     pub(crate) enclave_image_builder: GenericEnclaveImageBuilder<'a>,
 }
 
 impl<'a> EnclaveImageBuilder<'a> {
-    const INIT_BIN: &'static str = "init";
-    const GPU_MODULES: &'static [&'static str] = &[
-        "nvidia.ko",
-        "nvidia-uvm.ko",
-        "nvidia-drm.ko",
-        "nvidia-modeset.ko",
-    ];
     pub const INITRAMFS_FILENAME: &'static str = "initramfs.gz";
     pub const OVMF_FILENAME: &'static str = "OVMF.amdsev.fd";
 
@@ -52,99 +34,18 @@ impl<'a> EnclaveImageBuilder<'a> {
         docker_util: &dyn DockerUtil,
         enclave_settings: EnclaveSettings,
         user_config: UserConfig,
-        mut env_vars: Vec<String>,
-        _sender: std::sync::mpsc::Sender<crate::image::ImageToClean>,
+        env_vars: Vec<String>,
+        sender: std::sync::mpsc::Sender<crate::image::ImageToClean>,
     ) -> Result<SNPEnclavesMeasurements> {
-        let work_dir = self.enclave_image_builder.dir.path();
-
-        let start = Instant::now();
-        info!("Creating client FS block file...");
-        let file_system_config = if enclave_settings.gpu_passthrough {
-            self.enclave_image_builder
-                .create_block_file_with_nvidia_driver_payload(
-                    docker_util,
-                    &user_config,
-                    &enclave_settings.nvidia_driver_capabilities,
-                )
-                .await?
-        } else {
-            self.enclave_image_builder
-                .create_block_file(docker_util, &user_config)
-                .await?
-        };
-        info!(
-            "Client FS block file has been created in {:?}.",
-            start.elapsed()
-        );
-
-        let start = Instant::now();
-        let is_debug = enclave_settings.is_debug;
-        let enable_overlay_filesystem_persistence =
-            enclave_settings.enable_overlay_filesystem_persistence;
-        let ccm_backend_url = enclave_settings.ccm_backend_url.clone();
-        let dsm_configuration = enclave_settings.dsm_configuration.clone();
-
-        if enclave_settings.gpu_passthrough {
-            prepend_env(
-                &mut env_vars,
-                "LD_LIBRARY_PATH",
-                NVIDIA_DRIVER_LIBRARY_PATH,
-                None,
-            );
-            prepend_env(
-                &mut env_vars,
-                "PATH",
-                NVIDIA_DRIVER_BINARY_PATH,
-                Some(DEFAULT_PATH),
-            );
-            upsert_env(
-                &mut env_vars,
-                "NVIDIA_DRIVER_CAPABILITIES",
-                &enclave_settings.nvidia_driver_capabilities.join(","),
-            );
-        }
-
-        let enclave_manifest = EnclaveManifest {
+        QemuEnclaveImageBuilder::create_image(
+            self,
+            docker_util,
+            enclave_settings,
             user_config,
-            file_system_config,
-            is_debug,
             env_vars,
-            enable_overlay_filesystem_persistence,
-            ccm_backend_url,
-            dsm_configuration,
-        };
-
-        let enclave_manifest_data =
-            serde_json::to_vec(&enclave_manifest).map_err(|err| ConverterError {
-                message: format!("Failed serializing enclave settings file. {:?}", err),
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-        info!("Serialized enclave manifest in {:?}.", start.elapsed());
-
-        let enclave_base_tar_path = work_dir.join(crate::ENCLAVE_IMAGE_PATH);
-        let start = Instant::now();
-        info!("Exporting enclave-base image...");
-        let enclave_base_archive = self
-            .enclave_image_builder
-            .export_enclave_base_file_system(docker_util, &enclave_base_tar_path)
-            .await?;
-        info!("Exported enclave-base image in {:?}.", start.elapsed());
-
-        let initramfs_file_path = work_dir.join(Self::INITRAMFS_FILENAME);
-
-        info!("Creating initramfs archive...");
-        create_initramfs(
-            &initramfs_file_path,
-            enclave_base_archive,
-            &enclave_settings,
-            &enclave_manifest_data,
+            sender,
         )
-        .map_err(|e| ConverterError {
-            message: format!("Failed to create initramfs: {}", e),
-            kind: ConverterErrorKind::EnclaveImageCreation,
-        })?;
-
-        compute_launch_measurements(&enclave_settings, &initramfs_file_path).await
+        .await
     }
 
     pub(crate) fn get_enclave_base_details(
@@ -168,325 +69,67 @@ impl<'a> EnclaveImageBuilder<'a> {
     }
 }
 
-fn get_last_env_value(env_vars: &[String], key: &str) -> Option<String> {
-    let prefix = format!("{}=", key);
+#[async_trait::async_trait]
+impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
+    type Measurements = SNPEnclavesMeasurements;
+    type InitramfsBuilder = GpuSupportedInitramfsBuilder;
 
-    env_vars
-        .iter()
-        .rev()
-        .find_map(|env| env.strip_prefix(&prefix).map(|value| value.to_string()))
-}
-
-fn prepend_env(env_vars: &mut Vec<String>, key: &str, prefix: &str, default: Option<&str>) {
-    let current = get_last_env_value(env_vars, key)
-        .or_else(|| default.map(|value| value.to_string()))
-        .unwrap_or_default();
-
-    let value = if current.is_empty() {
-        prefix.to_string()
-    } else if current.split(':').any(|entry| entry == prefix) {
-        current
-    } else {
-        format!("{}:{}", prefix, current)
-    };
-
-    upsert_env(env_vars, key, &value);
-}
-
-fn upsert_env(env_vars: &mut Vec<String>, key: &str, value: &str) {
-    env_vars.push(format!("{}={}", key, value));
-}
-
-fn create_initramfs(
-    output_path: &Path,
-    mut enclave_base_archive: Archive<fs::File>,
-    enclave_settings: &EnclaveSettings,
-    enclave_manifest_data: &[u8],
-) -> std::result::Result<(), IoError> {
-    let run_cmd = get_run_cmd(&enclave_settings);
-
-    let blobs_dir = PathBuf::from(format!("{}/blobs", INSTALLATION_DIR));
-    let init = {
-        let subdir = if enclave_settings.gpu_passthrough {
-            BLOBS_SUBDIR_GPU_ENABLED
-        } else {
-            BLOBS_SUBDIR_GPU_DISABLED
-        };
-        let init_path = blobs_dir.join(subdir).join(EnclaveImageBuilder::INIT_BIN);
-        let init_data = fs::read(&init_path)?;
-        init_data
-    };
-
-    let mut fs_tree = FsTree::new()
-        .add_file("env", Cursor::new(get_env_vars(&enclave_settings.env_vars)))
-        .add_file("cmd", Cursor::new(run_cmd))
-        .add_executable("init", Cursor::new(init));
-
-    // Add enclave-base filesystem to rootfs
-    info!("Adding enclave-base filesystem to initramfs rootfs...");
-    fs_tree = add_enclave_base_to_initramfs(fs_tree, &mut enclave_base_archive)?;
-
-    let rootfs_installation_dir = PathBuf::from(format!("rootfs{}", INSTALLATION_DIR));
-    // Add dependencies available as resource
-    for resource in GenericEnclaveImageBuilder::IMAGE_BUILD_DEPENDENCIES {
-        let path = rootfs_installation_dir.join(resource.name);
-        let data = Cursor::new(resource.data);
-        fs_tree = if resource.is_executable {
-            fs_tree.add_executable(&path, data)
-        } else {
-            fs_tree.add_file(&path, data)
-        };
+    fn enclave_image_builder(&self) -> &GenericEnclaveImageBuilder<'a> {
+        &self.enclave_image_builder
     }
 
-    // Add enclave-settings.json generated at runtime.
-    fs_tree = fs_tree.add_file(
-        rootfs_installation_dir.join(GenericEnclaveImageBuilder::DEFAULT_ENCLAVE_SETTINGS_FILE),
-        Cursor::new(enclave_manifest_data.to_vec()),
-    );
+    fn ovmf_filename(&self) -> &'static str {
+        Self::OVMF_FILENAME
+    }
 
-    // Add GPU modules if enabled
-    if enclave_settings.gpu_passthrough {
-        info!("Adding gpu modules to initramfs...");
-        let module_dir = blobs_dir.join(BLOBS_SUBDIR_GPU_ENABLED);
-        let initramfs_module_path = Path::new("lib/modules");
+    fn initramfs_filename(&self) -> &'static str {
+        Self::INITRAMFS_FILENAME
+    }
 
-        for module in EnclaveImageBuilder::GPU_MODULES {
-            let module_path = module_dir.join(module);
-            let module_data = fs::read(module_path)?;
+    async fn create_block_file(
+        &self,
+        docker_util: &dyn DockerUtil,
+        user_config: &UserConfig,
+        enclave_settings: &EnclaveSettings,
+    ) -> Result<FileSystemConfig> {
+        let file_system_config = if enclave_settings.gpu_passthrough {
+            self.enclave_image_builder()
+                .create_block_file_with_nvidia_driver_payload(
+                    docker_util,
+                    &user_config,
+                    &enclave_settings.nvidia_driver_capabilities,
+                )
+                .await?
+        } else {
+            self.enclave_image_builder()
+                .create_block_file(docker_util, &user_config)
+                .await?
+        };
+        Ok(file_system_config)
+    }
 
-            // Add gpu drivers to initramfs root as they are loaded
-            // by init
-            fs_tree =
-                fs_tree.add_file(initramfs_module_path.join(module), Cursor::new(module_data));
+    fn update_env_vars(&self, enclave_settings: &EnclaveSettings, env_vars: &mut Vec<String>) {
+        if enclave_settings.gpu_passthrough {
+            insert_nvidia_env_vars(env_vars, &enclave_settings.nvidia_driver_capabilities)
         }
-
-        info!("Adding NVIDIA GSP firmware to initramfs...");
-        fs_tree = add_nvidia_firmware_to_initramfs(fs_tree)?;
     }
 
-    let start = Instant::now();
+    async fn compute_launch_measurements(
+        &self,
+        enclave_settings: &EnclaveSettings,
+        initramfs_file_path: &Path,
+    ) -> Result<Self::Measurements> {
+        let ovmf_path = Self::InitramfsBuilder::blobs_dir().join(self.ovmf_filename());
+        let kernel_path =
+            Self::InitramfsBuilder::kernel_blobs_dir(&enclave_settings).join("bzImage");
 
-    info!("Building initramfs, it may take a while depending on size of it...");
-    let output_file = fs::File::create(output_path)?;
-    Initramfs::from_fs_tree(fs_tree, output_file).map_err(|e| {
-        IoError::new(
-            IoErrorKind::Other,
-            format!("failed to build initramfs: {:?}", e),
-        )
-    })?;
-
-    info!(
-        "Built {} at {} in {:?}",
-        EnclaveImageBuilder::INITRAMFS_FILENAME,
-        output_path.display(),
-        start.elapsed()
-    );
-    Ok(())
-}
-
-async fn compute_launch_measurements(
-    enclave_settings: &EnclaveSettings,
-    initramfs_file_path: &Path,
-) -> Result<SNPEnclavesMeasurements> {
-    let blobs_dir = Path::new(INSTALLATION_DIR).join("blobs");
-    let ovmf_path = blobs_dir.join(EnclaveImageBuilder::OVMF_FILENAME);
-    let kernel_path = blobs_dir
-        .join(if enclave_settings.gpu_passthrough {
-            BLOBS_SUBDIR_GPU_ENABLED
-        } else {
-            BLOBS_SUBDIR_GPU_DISABLED
+        compute_snp_launch_measurement(&SnpMeasurementInputs {
+            ovmf: &ovmf_path,
+            kernel: &kernel_path,
+            initrd: Some(initramfs_file_path),
+            cmdline: Some("console=ttyS0 rdinit=/init loglevel=7"),
+            vcpus: 2,
         })
-        .join("bzImage");
-
-    compute_snp_launch_measurement(&SnpMeasurementInputs {
-        ovmf: &ovmf_path,
-        kernel: &kernel_path,
-        initrd: Some(initramfs_file_path),
-        // TODO: hardcoded for now so the pre-computed measurement matches
-        // the kernel cmdline QEMU passes at launch. Revisit once the proper
-        // cmdline source is wired up (e.g., a shared constant from parent_lib
-        // when RTE-917 lands).
-        cmdline: Some("console=ttyS0 rdinit=/init loglevel=7"),
-        vcpus: 2,
-    })
-    .await
-}
-
-fn add_nvidia_firmware_to_initramfs(fs_tree: FsTree) -> std::result::Result<FsTree, IoError> {
-    let firmware_root = Path::new(NVIDIA_DRIVER_FIRMWARE_PAYLOAD_ROOT);
-    if !firmware_root.exists() {
-        return Err(IoError::new(
-            IoErrorKind::NotFound,
-            format!(
-                "NVIDIA firmware payload root {} does not exist in the converter image",
-                firmware_root.display()
-            ),
-        ));
+        .await
     }
-
-    add_nvidia_firmware_dir_to_initramfs(fs_tree, firmware_root, firmware_root)
-}
-
-fn add_nvidia_firmware_dir_to_initramfs(
-    mut fs_tree: FsTree,
-    root: &Path,
-    dir: &Path,
-) -> std::result::Result<FsTree, IoError> {
-    for entry in fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        let file_type = entry.file_type()?;
-        let relative_path = path.strip_prefix(root).map_err(|err| {
-            IoError::new(
-                IoErrorKind::Other,
-                format!(
-                    "failed to make NVIDIA firmware path {} relative to {}. {:?}",
-                    path.display(),
-                    root.display(),
-                    err
-                ),
-            )
-        })?;
-        let relative_path = relative_path.to_str().ok_or(IoError::new(
-            IoErrorKind::Other,
-            format!("invalid NVIDIA firmware path: {}", path.display()),
-        ))?;
-
-        if file_type.is_dir() {
-            fs_tree = fs_tree.add_directory(relative_path);
-            fs_tree = add_nvidia_firmware_dir_to_initramfs(fs_tree, root, &path)?;
-        } else if file_type.is_file() {
-            let data = fs::read(&path)?;
-            fs_tree = fs_tree.add_file(relative_path, Cursor::new(data));
-        } else {
-            warn!(
-                "Skipping unsupported NVIDIA firmware entry {}",
-                path.display()
-            );
-        }
-    }
-
-    Ok(fs_tree)
-}
-
-fn add_enclave_base_to_initramfs(
-    mut fs_tree: FsTree,
-    enclave_base_archive: &mut tar::Archive<fs::File>,
-) -> std::result::Result<FsTree, IoError> {
-    let start = Instant::now();
-    let mut entries_count = 0u64;
-    let mut files_count = 0u64;
-    let mut directories_count = 0u64;
-    let mut links_count = 0u64;
-    let mut bytes_read = 0u64;
-    let mut last_logged_bytes = 0u64;
-
-    let entries = enclave_base_archive.entries()?;
-    for entry in entries {
-        let mut entry = entry?;
-        entries_count += 1;
-
-        let path = entry.path()?;
-        let target_path = Path::new("rootfs").join(&path);
-
-        let header = entry.header();
-        // Some tar archives doesn't preserve modes.
-        let mut mode = header.mode()?;
-
-        // Tar entries do not contains file type bits of mode, instead
-        // only contains permissions part. Here, we re-set the file type
-        // related bits.
-        let file_type = match header.entry_type() {
-            EntryType::Regular | EntryType::Continuous => SFlag::S_IFREG,
-            EntryType::Directory => SFlag::S_IFDIR,
-            EntryType::Symlink => SFlag::S_IFLNK,
-            EntryType::Link => {
-                warn!(
-                    "Hard link detected: {}, hard links are treated it as sym links...",
-                    path.display(),
-                );
-                SFlag::S_IFLNK
-            }
-            rest => {
-                warn!(
-                    "Unsupported tar entry type: {:?}, file: {}",
-                    rest,
-                    path.display()
-                );
-                return Err(IoError::new(
-                    IoErrorKind::Other,
-                    format!("unsupported tar entry: {}", path.display()),
-                ));
-            }
-        };
-        mode |= file_type.bits() as u32;
-
-        let entry_type = header.entry_type();
-        fs_tree = if entry_type.is_dir() {
-            directories_count += 1;
-            fs_tree.add_directory_with_permissions(&target_path, mode)
-        } else if entry_type.is_symlink() || entry_type.is_hard_link() {
-            // TODO: For now we're treating a hardlink as an softlink.
-            // Hard link support is to be added to the fortanix-vme-initramfs.
-            links_count += 1;
-            let link_target = entry
-                .link_name()?
-                .ok_or(IoError::new(IoErrorKind::Other, "missing link target"))?;
-            fs_tree.add_symlink_with_permissions(&target_path, link_target, mode)
-        } else {
-            files_count += 1;
-            let mut data = Vec::new();
-            entry.read_to_end(&mut data)?;
-            bytes_read += data.len() as u64;
-            fs_tree.add_file_with_permissions(&target_path, Cursor::new(data), mode)
-        };
-
-        if entries_count % 1000 == 0
-            || bytes_read.saturating_sub(last_logged_bytes) >= 256 * 1024 * 1024
-        {
-            info!(
-                "Adding enclave-base to initramfs: entries={}, files={}, directories={}, links={}, bytes_read={} MiB, elapsed={:?}, latest={}",
-                entries_count,
-                files_count,
-                directories_count,
-                links_count,
-                bytes_read / 1024 / 1024,
-                start.elapsed(),
-                target_path.display(),
-            );
-            last_logged_bytes = bytes_read;
-        }
-    }
-
-    info!(
-        "Added enclave-base to initramfs: entries={}, files={}, directories={}, links={}, bytes_read={} MiB, elapsed={:?}",
-        entries_count,
-        files_count,
-        directories_count,
-        links_count,
-        bytes_read / 1024 / 1024,
-        start.elapsed()
-    );
-
-    Ok(fs_tree)
-}
-
-// Extends the env variables set in conversion request with
-// the ones expected by `init` binary.
-fn get_env_vars(enclave_env_vars: &Vec<String>) -> String {
-    let mut env_vars = enclave_env_vars.clone();
-    // Add PATH env variables.
-    env_vars.push("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_owned());
-    env_vars.join("\n")
-}
-
-// Formats the command based on the expectation of `init` binary.
-fn get_run_cmd(enclave_settings: &EnclaveSettings) -> String {
-    let run_cmd = GenericEnclaveImageBuilder::enclave_command_string(
-        enclave_settings,
-        &Path::new(INSTALLATION_DIR),
-        "enclave",
-    );
-
-    format!("/bin/sh\n-c\n{}", run_cmd)
 }

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -93,7 +93,7 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         enclave_settings: &EnclaveSettings,
     ) -> Result<FileSystemConfig> {
         let file_system_config = if enclave_settings.gpu_passthrough {
-            self.enclave_image_builder()
+            self.enclave_image_builder
                 .create_block_file_with_nvidia_driver_payload(
                     docker_util,
                     &user_config,
@@ -101,7 +101,7 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
                 )
                 .await?
         } else {
-            self.enclave_image_builder()
+            self.enclave_image_builder
                 .create_block_file(docker_util, &user_config)
                 .await?
         };

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use api_model::enclave::{FileSystemConfig, UserConfig};
 use api_model::snp::{SNPEnclavesConversionRequestOptions, SNPEnclavesMeasurements};
 
+use crate::image_builder::blob_finder::BlobFinder;
 use crate::image_builder::enclave::initramfs::GpuSupportedInitramfsBuilder;
 use crate::image_builder::enclave::nvidia::insert_nvidia_env_vars;
 use crate::image_builder::enclave::qemu::QemuEnclaveImageBuilder;
@@ -20,7 +21,6 @@ use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::DockerUtil;
 use crate::Result;
-use crate::image_builder::blob_finder::BlobFinder;
 
 pub(crate) struct EnclaveImageBuilder<'a> {
     pub(crate) enclave_image_builder: GenericEnclaveImageBuilder<'a>,

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use api_model::enclave::{FileSystemConfig, UserConfig};
 use api_model::snp::{SNPEnclavesConversionRequestOptions, SNPEnclavesMeasurements};
 
-use crate::image_builder::enclave::initramfs::{GpuSupportedInitramfsBuilder, InitramfsBuilder};
+use crate::image_builder::enclave::initramfs::GpuSupportedInitramfsBuilder;
 use crate::image_builder::enclave::nvidia::insert_nvidia_env_vars;
 use crate::image_builder::enclave::qemu::QemuEnclaveImageBuilder;
 use crate::image_builder::enclave::snp_measurement::{
@@ -20,6 +20,7 @@ use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::DockerUtil;
 use crate::Result;
+use crate::image_builder::blob_finder::BlobFinder;
 
 pub(crate) struct EnclaveImageBuilder<'a> {
     pub(crate) enclave_image_builder: GenericEnclaveImageBuilder<'a>,
@@ -119,9 +120,8 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         enclave_settings: &EnclaveSettings,
         initramfs_file_path: &Path,
     ) -> Result<Self::Measurements> {
-        let ovmf_path = Self::InitramfsBuilder::blobs_dir().join(self.ovmf_filename());
-        let kernel_path =
-            Self::InitramfsBuilder::kernel_blobs_dir(&enclave_settings).join("bzImage");
+        let ovmf_path = BlobFinder::ovmf_path(self.ovmf_filename());
+        let kernel_path = BlobFinder::kernel_path(enclave_settings.gpu_passthrough);
 
         compute_snp_launch_measurement(&SnpMeasurementInputs {
             ovmf: &ovmf_path,

--- a/tools/container-converter/src/image_builder/enclave/tdx.rs
+++ b/tools/container-converter/src/image_builder/enclave/tdx.rs
@@ -7,14 +7,15 @@
 use std::env;
 use std::path::Path;
 
-use api_model::enclave::UserConfig;
+use api_model::enclave::{FileSystemConfig, UserConfig};
 use api_model::tdx::{TDXEnclavesConversionRequestOptions, TDXEnclavesMeasurements};
 use api_model::HexString;
 
+use crate::image_builder::enclave::initramfs::GpuSupportedInitramfsBuilder;
+use crate::image_builder::enclave::nvidia::insert_nvidia_env_vars;
 use crate::image_builder::enclave::qemu::QemuEnclaveImageBuilder;
 use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
-use crate::image_builder::INSTALLATION_DIR;
 use crate::DockerUtil;
 use crate::Result;
 
@@ -69,7 +70,7 @@ impl<'a> EnclaveImageBuilder<'a> {
 #[async_trait::async_trait]
 impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
     type Measurements = TDXEnclavesMeasurements;
-    const gpu_passthrough_supported: bool = true;
+    type InitramfsBuilder = GpuSupportedInitramfsBuilder;
 
     fn enclave_image_builder(&self) -> &GenericEnclaveImageBuilder<'a> {
         &self.enclave_image_builder
@@ -79,12 +80,46 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         Self::OVMF_FILENAME
     }
 
+    fn initramfs_filename(&self) -> &'static str {
+        Self::INITRAMFS_FILENAME
+    }
+
+    async fn create_block_file(
+        &self,
+        docker_util: &dyn DockerUtil,
+        user_config: &UserConfig,
+        enclave_settings: &EnclaveSettings,
+    ) -> Result<FileSystemConfig> {
+        let file_system_config = if enclave_settings.gpu_passthrough {
+            self.enclave_image_builder
+                .create_block_file_with_nvidia_driver_payload(
+                    docker_util,
+                    &user_config,
+                    &enclave_settings.nvidia_driver_capabilities,
+                )
+                .await?
+        } else {
+            self.enclave_image_builder
+                .create_block_file(docker_util, &user_config)
+                .await?
+        };
+        Ok(file_system_config)
+    }
+
+    fn update_env_vars(&self, enclave_settings: &EnclaveSettings, env_vars: &mut Vec<String>) {
+        if enclave_settings.gpu_passthrough {
+            insert_nvidia_env_vars(env_vars, &enclave_settings.nvidia_driver_capabilities)
+        }
+    }
+
     async fn compute_launch_measurements(
         &self,
         _enclave_settings: &EnclaveSettings,
         _initramfs_file_path: &Path,
     ) -> Result<Self::Measurements> {
         // TODO (RTE-998): Implement actual measurements call.
+        let _ovmf = self.ovmf_filename();
+
         Ok(TDXEnclavesMeasurements {
             mrtd: HexString::new([0]),
             rtmr0: HexString::new([0]),

--- a/tools/container-converter/src/image_builder/enclave/tdx.rs
+++ b/tools/container-converter/src/image_builder/enclave/tdx.rs
@@ -8,8 +8,8 @@ use std::env;
 use std::path::Path;
 
 use api_model::enclave::{FileSystemConfig, UserConfig};
-use api_model::tdx::{TDXEnclavesConversionRequestOptions, TDXEnclavesMeasurements};
-use api_model::HexString;
+use api_model::tdx::TDXEnclaveMeasurements;
+use api_model::{EnclavesOptions, HexString};
 
 use crate::image_builder::enclave::initramfs::GpuSupportedInitramfsBuilder;
 use crate::image_builder::enclave::nvidia::insert_nvidia_env_vars;
@@ -34,7 +34,7 @@ impl<'a> EnclaveImageBuilder<'a> {
         user_config: UserConfig,
         env_vars: Vec<String>,
         sender: std::sync::mpsc::Sender<crate::image::ImageToClean>,
-    ) -> Result<TDXEnclavesMeasurements> {
+    ) -> Result<TDXEnclaveMeasurements> {
         QemuEnclaveImageBuilder::create_image(
             self,
             docker_util,
@@ -47,7 +47,7 @@ impl<'a> EnclaveImageBuilder<'a> {
     }
 
     pub(crate) fn get_enclave_base_details(
-        enclaves_options: &TDXEnclavesConversionRequestOptions,
+        enclaves_options: &EnclavesOptions,
     ) -> (String, String) {
         let image_name = env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
             if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
@@ -69,7 +69,7 @@ impl<'a> EnclaveImageBuilder<'a> {
 
 #[async_trait::async_trait]
 impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
-    type Measurements = TDXEnclavesMeasurements;
+    type Measurements = TDXEnclaveMeasurements;
     type InitramfsBuilder = GpuSupportedInitramfsBuilder;
 
     fn enclave_image_builder(&self) -> &GenericEnclaveImageBuilder<'a> {
@@ -120,7 +120,7 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         // TODO (RTE-998): Implement actual measurements call.
         let _ovmf = self.ovmf_filename();
 
-        Ok(TDXEnclavesMeasurements {
+        Ok(TDXEnclaveMeasurements {
             mrtd: HexString::new([0]),
             rtmr0: HexString::new([0]),
             rtmr1: HexString::new([0]),

--- a/tools/container-converter/src/image_builder/enclave/tdx.rs
+++ b/tools/container-converter/src/image_builder/enclave/tdx.rs
@@ -46,9 +46,7 @@ impl<'a> EnclaveImageBuilder<'a> {
         .await
     }
 
-    pub(crate) fn get_enclave_base_details(
-        enclaves_options: &EnclavesOptions,
-    ) -> (String, String) {
+    pub(crate) fn get_enclave_base_details(enclaves_options: &EnclavesOptions) -> (String, String) {
         let image_name = env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
             if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
                 crate::ENCLAVE_IMAGE_TDX_GPU.to_owned()

--- a/tools/container-converter/src/image_builder/enclave/tdx.rs
+++ b/tools/container-converter/src/image_builder/enclave/tdx.rs
@@ -7,13 +7,14 @@
 use std::env;
 use std::path::Path;
 
-use api_model::enclave::{FileSystemConfig, UserConfig};
-use api_model::simulator::SimulatorEnclavesConversionRequestOptions;
+use api_model::enclave::UserConfig;
+use api_model::tdx::{TDXEnclavesConversionRequestOptions, TDXEnclavesMeasurements};
+use api_model::HexString;
 
-use crate::image_builder::enclave::initramfs::BasicInitramfsBuilder;
 use crate::image_builder::enclave::qemu::QemuEnclaveImageBuilder;
 use crate::image_builder::enclave::EnclaveSettings;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
+use crate::image_builder::INSTALLATION_DIR;
 use crate::DockerUtil;
 use crate::Result;
 
@@ -23,6 +24,7 @@ pub(crate) struct EnclaveImageBuilder<'a> {
 
 impl<'a> EnclaveImageBuilder<'a> {
     pub const INITRAMFS_FILENAME: &'static str = "initramfs.gz";
+    pub const OVMF_FILENAME: &'static str = "OVMF.inteltdx.fd";
 
     pub(crate) async fn create_image(
         &self,
@@ -31,7 +33,7 @@ impl<'a> EnclaveImageBuilder<'a> {
         user_config: UserConfig,
         env_vars: Vec<String>,
         sender: std::sync::mpsc::Sender<crate::image::ImageToClean>,
-    ) -> Result<()> {
+    ) -> Result<TDXEnclavesMeasurements> {
         QemuEnclaveImageBuilder::create_image(
             self,
             docker_util,
@@ -44,44 +46,37 @@ impl<'a> EnclaveImageBuilder<'a> {
     }
 
     pub(crate) fn get_enclave_base_details(
-        _enclaves_options: &SimulatorEnclavesConversionRequestOptions,
+        enclaves_options: &TDXEnclavesConversionRequestOptions,
     ) -> (String, String) {
-        (
-            env::var("ENCLAVE_IMAGE").unwrap_or(crate::ENCLAVE_IMAGE.to_owned()),
-            crate::ENCLAVE_IMAGE_PATH.to_owned(),
-        )
+        let image_name = env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
+            if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
+                crate::ENCLAVE_IMAGE_TDX_GPU.to_owned()
+            } else {
+                crate::ENCLAVE_IMAGE.to_owned()
+            }
+        });
+
+        let image_path = if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
+            crate::ENCLAVE_GPU_IMAGE_PATH.to_owned()
+        } else {
+            crate::ENCLAVE_IMAGE_PATH.to_owned()
+        };
+
+        (image_name, image_path)
     }
 }
 
 #[async_trait::async_trait]
 impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
-    type Measurements = ();
-    type InitramfsBuilder = BasicInitramfsBuilder;
+    type Measurements = TDXEnclavesMeasurements;
+    const gpu_passthrough_supported: bool = true;
 
     fn enclave_image_builder(&self) -> &GenericEnclaveImageBuilder<'a> {
         &self.enclave_image_builder
     }
 
-    #[allow(unused)]
     fn ovmf_filename(&self) -> &'static str {
-        ""
-    }
-
-    fn initramfs_filename(&self) -> &'static str {
-        Self::INITRAMFS_FILENAME
-    }
-
-    async fn create_block_file(
-        &self,
-        docker_util: &dyn DockerUtil,
-        user_config: &UserConfig,
-        _enclave_settings: &EnclaveSettings,
-    ) -> Result<FileSystemConfig> {
-        let file_system_config = self
-            .enclave_image_builder()
-            .create_block_file(docker_util, &user_config)
-            .await?;
-        Ok(file_system_config)
+        Self::OVMF_FILENAME
     }
 
     async fn compute_launch_measurements(
@@ -89,6 +84,13 @@ impl<'a> QemuEnclaveImageBuilder<'a> for EnclaveImageBuilder<'a> {
         _enclave_settings: &EnclaveSettings,
         _initramfs_file_path: &Path,
     ) -> Result<Self::Measurements> {
-        Ok(())
+        // TODO (RTE-998): Implement actual measurements call.
+        Ok(TDXEnclavesMeasurements {
+            mrtd: HexString::new([0]),
+            rtmr0: HexString::new([0]),
+            rtmr1: HexString::new([0]),
+            rtmr2: HexString::new([0]),
+            rtmr3: HexString::new([0]),
+        })
     }
 }

--- a/tools/container-converter/src/image_builder/mod.rs
+++ b/tools/container-converter/src/image_builder/mod.rs
@@ -8,9 +8,9 @@ use std::path::Path;
 
 use crate::{ConverterError, ConverterErrorKind};
 
+pub(crate) mod blob_finder;
 pub(crate) mod enclave;
 pub(crate) mod parent;
-pub(crate) mod blob_finder;
 
 const INSTALLATION_DIR: &'static str = "/opt/fortanix/enclave-os";
 const ORIG_ENV_LIST_PATH: &'static str = "original-parent.env";

--- a/tools/container-converter/src/image_builder/mod.rs
+++ b/tools/container-converter/src/image_builder/mod.rs
@@ -10,6 +10,7 @@ use crate::{ConverterError, ConverterErrorKind};
 
 pub(crate) mod enclave;
 pub(crate) mod parent;
+pub(crate) mod blob_finder;
 
 const INSTALLATION_DIR: &'static str = "/opt/fortanix/enclave-os";
 const ORIG_ENV_LIST_PATH: &'static str = "original-parent.env";

--- a/tools/container-converter/src/image_builder/mod.rs
+++ b/tools/container-converter/src/image_builder/mod.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use crate::{ConverterError, ConverterErrorKind};
 
+#[cfg(any(platform = "snp", platform = "tdx", platform = "simulator"))]
 pub(crate) mod blob_finder;
 pub(crate) mod enclave;
 pub(crate) mod parent;

--- a/tools/container-converter/src/image_builder/parent/mod.rs
+++ b/tools/container-converter/src/image_builder/parent/mod.rs
@@ -14,6 +14,11 @@ pub(crate) mod snp;
 #[cfg(platform = "snp")]
 pub(crate) use self::snp::ParentImageBuilder as PlatformParentImageBuilder;
 
+#[cfg(platform = "tdx")]
+pub(crate) mod tdx;
+#[cfg(platform = "tdx")]
+pub(crate) use self::tdx::ParentImageBuilder as PlatformParentImageBuilder;
+
 #[cfg(platform = "simulator")]
 pub(crate) mod simulator;
 #[cfg(platform = "simulator")]

--- a/tools/container-converter/src/image_builder/parent/mod.rs
+++ b/tools/container-converter/src/image_builder/parent/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod simulator;
 #[cfg(platform = "simulator")]
 pub(crate) use self::simulator::ParentImageBuilder as PlatformParentImageBuilder;
 
-#[cfg(any(platform = "snp", platform = "tdx"))]
+#[cfg(any(platform = "snp", platform = "tdx", platform = "simulator"))]
 pub(crate) mod qemu;
 
 use std::fs;

--- a/tools/container-converter/src/image_builder/parent/mod.rs
+++ b/tools/container-converter/src/image_builder/parent/mod.rs
@@ -24,6 +24,9 @@ pub(crate) mod simulator;
 #[cfg(platform = "simulator")]
 pub(crate) use self::simulator::ParentImageBuilder as PlatformParentImageBuilder;
 
+#[cfg(any(platform = "snp", platform = "tdx"))]
+pub(crate) mod qemu;
+
 use std::fs;
 use std::io::Write;
 use std::path::Path;

--- a/tools/container-converter/src/image_builder/parent/mod.rs
+++ b/tools/container-converter/src/image_builder/parent/mod.rs
@@ -46,6 +46,8 @@ pub struct ParentImageBuilder<'a> {
 impl<'a> ParentImageBuilder<'a> {
     pub(crate) const DEFAULT_CPU_COUNT: u8 = 2;
 
+    // Note that, the following must be in Megabytes unit
+    // otherwise it may break qemu invocation
     pub(crate) const DEFAULT_MEMORY_SIZE: u64 = 2048;
 
     pub(crate) const STARTUP_SCRIPT_NAME: &'static str = "start-parent.sh";

--- a/tools/container-converter/src/image_builder/parent/qemu.rs
+++ b/tools/container-converter/src/image_builder/parent/qemu.rs
@@ -217,7 +217,10 @@ pub(crate) trait QemuParentImageBuilder<'a> {
         let kernel_path = BlobFinder::kernel_path(gpu_passthrough);
         if !kernel_path.exists() {
             return Err(ConverterError {
-                message: format!("Blob bzImage could not be found at: {}!", kernel_path.display()),
+                message: format!(
+                    "Blob bzImage could not be found at: {}!",
+                    kernel_path.display()
+                ),
                 kind: ConverterErrorKind::RequisitesCreation,
             });
         }
@@ -226,7 +229,10 @@ pub(crate) trait QemuParentImageBuilder<'a> {
         let kernel_config_path = BlobFinder::kernel_config_path(gpu_passthrough);
         if !kernel_config_path.exists() {
             return Err(ConverterError {
-                message: format!("Blob bzImage.config could not be found at: {}!", kernel_config_path.display()),
+                message: format!(
+                    "Blob bzImage.config could not be found at: {}!",
+                    kernel_config_path.display()
+                ),
                 kind: ConverterErrorKind::RequisitesCreation,
             });
         }

--- a/tools/container-converter/src/image_builder/parent/qemu.rs
+++ b/tools/container-converter/src/image_builder/parent/qemu.rs
@@ -1,0 +1,237 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use docker_image_reference::Reference as DockerReference;
+use log::info;
+
+use crate::docker::DockerUtil;
+use crate::file::{BuildContext, DockerCopyArgs, DockerFile};
+use crate::image::ImageWithDetails;
+use crate::image_builder::enclave::GenericEnclaveImageBuilder;
+use crate::image_builder::parent::ParentImageBuilder as GenericParentImageBuilder;
+use crate::image_builder::{rust_log_env_var, INSTALLATION_DIR, ORIG_ENV_LIST_PATH};
+use crate::{file, ConverterError, ConverterErrorKind, Result};
+
+use super::move_file;
+use crate::image_builder::blob_finder::BlobFinder;
+
+#[async_trait]
+pub(crate) trait QemuParentImageBuilder<'a> {
+    fn parent_image_builder(&self) -> &GenericParentImageBuilder<'a>;
+    fn cpu_count(&self) -> u8;
+    fn mem_size(&self) -> &Option<api_model::ByteUnit>;
+    fn enable_gpu_passthrough(&self) -> Option<bool>;
+    fn platform_name(&self) -> &'static str;
+    fn initramfs_filename(&self) -> &'static str;
+
+    fn ovmf_filename(&self) -> &'static str {
+        "OVMF.amdsev.fd"
+    }
+
+    async fn create_image(
+        &self,
+        docker_util: &dyn DockerUtil,
+        image_reference: DockerReference<'a>,
+    ) -> Result<ImageWithDetails<'a>> {
+        let build_context =
+            BuildContext::new(&self.parent_image_builder().dir.path()).map_err(|message| {
+                ConverterError {
+                    message,
+                    kind: ConverterErrorKind::RequisitesCreation,
+                }
+            })?;
+
+        // Move initramfs built by enclave image builder to build context.
+        self.parent_image_builder()
+            .move_enclave_files_into_build_context(
+                build_context.path(),
+                self.initramfs_filename(),
+            )?;
+
+        let blob_filenames = self.move_blobs_into_build_context(&build_context)?;
+        let mut copy_dependencies: Vec<String> = vec![
+            GenericParentImageBuilder::STARTUP_SCRIPT_NAME.to_string(),
+            GenericParentImageBuilder::BINARY_NAME.to_string(),
+            self.initramfs_filename().to_string(),
+            GenericEnclaveImageBuilder::BLOCK_FILE_OUT.to_string(),
+        ];
+        copy_dependencies.extend(blob_filenames);
+
+        self.create_requisites(&build_context, &copy_dependencies)
+            .map_err(|message| ConverterError {
+                message,
+                kind: ConverterErrorKind::RequisitesCreation,
+            })?;
+        info!("Parent prerequisites have been created!");
+
+        let build_context_archive_file = build_context
+            .package_into_archive(
+                &self
+                    .parent_image_builder()
+                    .dir
+                    .path()
+                    .join("parent-build-context.tar"),
+            )
+            .map_err(|message| ConverterError {
+                message,
+                kind: ConverterErrorKind::RequisitesCreation,
+            })?;
+
+        let result = docker_util
+            .create_image_from_archive(image_reference, build_context_archive_file)
+            .await
+            .map_err(|message| ConverterError {
+                message,
+                kind: ConverterErrorKind::ParentImageCreation,
+            })?;
+
+        info!("Parent image has been created!");
+
+        Ok(result)
+    }
+
+    fn create_requisites(
+        &self,
+        build_context: &BuildContext,
+        copy_dependencies: &[String],
+    ) -> std::result::Result<(), String> {
+        let docker_file = self.docker_file_contents(copy_dependencies.to_vec());
+
+        build_context.create_docker_file(&docker_file)?;
+
+        build_context.create_resources(GenericParentImageBuilder::IMAGE_BUILD_DEPENDENCIES)?;
+
+        let startup_script_path = build_context
+            .path()
+            .join(GenericParentImageBuilder::STARTUP_SCRIPT_NAME);
+
+        self.parent_image_builder()
+            .append_start_enclave_command(&startup_script_path)?;
+
+        if cfg!(debug_assertions) {
+            file::log_file(&startup_script_path)?;
+        }
+
+        Ok(())
+    }
+
+    fn docker_file_contents(&self, items: Vec<String>) -> DockerFile {
+        let add = DockerCopyArgs {
+            items,
+            destination: INSTALLATION_DIR.to_string() + "/",
+        };
+
+        let run_parent_cmd = Path::new(INSTALLATION_DIR)
+            .join("start-parent.sh")
+            .display()
+            .to_string();
+
+        let log_env = rust_log_env_var("parent");
+        let cpu_count_env = self.cpu_count_env_var();
+        let mem_size_env = self.mem_size_env_var();
+        let eos_debug_env = GenericParentImageBuilder::eos_debug_env_var();
+
+        let env_vars = vec![log_env, cpu_count_env, mem_size_env, eos_debug_env];
+
+        let abs_orig_env_list_path = Path::new(INSTALLATION_DIR)
+            .join(ORIG_ENV_LIST_PATH)
+            .display()
+            .to_string();
+        let save_envs_run_command = format!("printenv > {}", abs_orig_env_list_path);
+
+        let from = self.parent_image_builder().parent_image.clone();
+
+        DockerFile {
+            from,
+            add: Some(add),
+            env: env_vars,
+            run: Some(save_envs_run_command),
+            cmd: None,
+            entrypoint: Some(vec![
+                run_parent_cmd,
+                "--platform".to_string(),
+                self.platform_name().to_string(),
+            ]),
+        }
+    }
+
+    fn cpu_count_env_var(&self) -> String {
+        let cpu_count = if self.cpu_count() == 0 {
+            GenericParentImageBuilder::DEFAULT_CPU_COUNT
+        } else {
+            self.cpu_count()
+        };
+        format!("CPU_COUNT={}", cpu_count)
+    }
+
+    fn mem_size_env_var(&self) -> String {
+        format!(
+            "MEM_SIZE={}",
+            self.mem_size()
+                .as_ref()
+                .map(|e| e.to_mb())
+                .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE)
+        )
+    }
+
+    // Moves blobs located at system to build context and returns filenames only
+    fn move_blobs_into_build_context(&self, build_context: &BuildContext) -> Result<Vec<String>> {
+        let blobs = self.collect_blob_paths()?;
+        let mut filenames = Vec::with_capacity(blobs.len());
+        for blob in blobs {
+            let filename = blob
+                .file_name()
+                .and_then(|f| f.to_str())
+                .ok_or(ConverterError {
+                    message: format!("Invalid path: {}", blob.display()),
+                    kind: ConverterErrorKind::RequisitesCreation,
+                })?;
+            let dest = build_context.path().join(filename);
+            move_file(blob.as_path(), &dest)?;
+            filenames.push(filename.to_owned());
+        }
+
+        Ok(filenames)
+    }
+
+    fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
+        let mut ret = Vec::new();
+
+        let ovmf_path = BlobFinder::ovmf_path(self.ovmf_filename());
+        if !ovmf_path.exists() {
+            return Err(ConverterError {
+                message: format!("OVMF file could not be found at: {}", ovmf_path.display()),
+                kind: ConverterErrorKind::RequisitesCreation,
+            });
+        }
+        ret.push(ovmf_path);
+
+        let gpu_passthrough = self.enable_gpu_passthrough().unwrap_or(false);
+
+        let kernel_path = BlobFinder::kernel_path(gpu_passthrough);
+        if !kernel_path.exists() {
+            return Err(ConverterError {
+                message: format!("Blob bzImage could not be found at: {}!", kernel_path.display()),
+                kind: ConverterErrorKind::RequisitesCreation,
+            });
+        }
+        ret.push(kernel_path);
+
+        let kernel_config_path = BlobFinder::kernel_config_path(gpu_passthrough);
+        if !kernel_config_path.exists() {
+            return Err(ConverterError {
+                message: format!("Blob bzImage.config could not be found at: {}!", kernel_config_path.display()),
+                kind: ConverterErrorKind::RequisitesCreation,
+            });
+        }
+        ret.push(kernel_config_path);
+
+        Ok(ret)
+    }
+}

--- a/tools/container-converter/src/image_builder/parent/qemu.rs
+++ b/tools/container-converter/src/image_builder/parent/qemu.rs
@@ -29,10 +29,7 @@ pub(crate) trait QemuParentImageBuilder<'a> {
     fn enable_gpu_passthrough(&self) -> Option<bool>;
     fn platform_name(&self) -> &'static str;
     fn initramfs_filename(&self) -> &'static str;
-
-    fn ovmf_filename(&self) -> &'static str {
-        "OVMF.amdsev.fd"
-    }
+    fn ovmf_filename(&self) -> &'static str;
 
     async fn create_image(
         &self,
@@ -171,13 +168,15 @@ pub(crate) trait QemuParentImageBuilder<'a> {
     }
 
     fn mem_size_env_var(&self) -> String {
-        format!(
-            "MEM_SIZE={}",
-            self.mem_size()
-                .as_ref()
-                .map(|e| e.to_mb())
-                .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE)
-        )
+        let mem_size = self
+            .mem_size()
+            .as_ref()
+            .map(|e| e.to_mb())
+            .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE);
+
+        // Note that: we explictly add suffix to make it consistent between
+        // different qemu argument such as memory size & memory backend.
+        format!("MEM_SIZE={}M", mem_size)
     }
 
     // Moves blobs located at system to build context and returns filenames only

--- a/tools/container-converter/src/image_builder/parent/qemu.rs
+++ b/tools/container-converter/src/image_builder/parent/qemu.rs
@@ -175,7 +175,7 @@ pub(crate) trait QemuParentImageBuilder<'a> {
             .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE);
 
         // Note that: we explictly add suffix to make it consistent between
-        // different qemu argument such as memory size & memory backend.
+        // different qemu arguments such as memory size & memory backend.
         format!("MEM_SIZE={}M", mem_size)
     }
 

--- a/tools/container-converter/src/image_builder/parent/simulator.rs
+++ b/tools/container-converter/src/image_builder/parent/simulator.rs
@@ -6,205 +6,64 @@
 
 use std::path::{Path, PathBuf};
 
-use api_model::simulator::SimulatorEnclavesConversionRequestOptions;
+use api_model::EnclavesOptions;
 use docker_image_reference::Reference as DockerReference;
-use log::info;
 
 use crate::docker::DockerUtil;
-use crate::file::{BuildContext, DockerCopyArgs, DockerFile};
 use crate::image::ImageWithDetails;
 use crate::image_builder::enclave::simulator::EnclaveImageBuilder as SimulatorEnclaveImageBuilder;
-use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::image_builder::parent::ParentImageBuilder as GenericParentImageBuilder;
-use crate::image_builder::{rust_log_env_var, INSTALLATION_DIR, ORIG_ENV_LIST_PATH};
-use crate::{file, ConverterError, ConverterErrorKind, Result};
+use crate::Result;
 
-use super::move_file;
+use super::qemu::QemuParentImageBuilder;
 
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
-    pub(crate) start_options: SimulatorEnclavesConversionRequestOptions,
+    pub(crate) start_options: EnclavesOptions,
 }
 
 impl<'a> ParentImageBuilder<'a> {
-    pub(crate) const IMAGE_COPY_DEPENDENCIES: &'static [&'static str] = &[
-        GenericParentImageBuilder::STARTUP_SCRIPT_NAME,
-        GenericParentImageBuilder::BINARY_NAME,
-        SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME,
-        GenericEnclaveImageBuilder::BLOCK_FILE_OUT,
-    ];
-
     pub(crate) async fn create_image(
         &self,
         docker_util: &dyn DockerUtil,
         image_reference: DockerReference<'a>,
     ) -> Result<ImageWithDetails<'a>> {
-        let build_context =
-            BuildContext::new(&self.parent_image_builder.dir.path()).map_err(|message| {
-                ConverterError {
-                    message,
-                    kind: ConverterErrorKind::RequisitesCreation,
-                }
-            })?;
+        QemuParentImageBuilder::create_image(self, docker_util, image_reference).await
+    }
+}
 
-        // Move initramfs built by enclave image builder to build context.
-        self.parent_image_builder
-            .move_enclave_files_into_build_context(
-                build_context.path(),
-                SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME,
-            )?;
-
-        let blob_filenames = self.move_blobs_into_build_context(&build_context)?;
-        let mut copy_dependencies: Vec<String> = Self::IMAGE_COPY_DEPENDENCIES
-            .iter()
-            .map(|e| e.to_string())
-            .collect();
-        copy_dependencies.extend(blob_filenames);
-
-        self.create_requisites(&build_context, &copy_dependencies)
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-        info!("Parent prerequisites have been created!");
-
-        let build_context_archive_file = build_context
-            .package_into_archive(
-                &self
-                    .parent_image_builder
-                    .dir
-                    .path()
-                    .join("parent-build-context.tar"),
-            )
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-
-        let result = docker_util
-            .create_image_from_archive(image_reference, build_context_archive_file)
-            .await
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::ParentImageCreation,
-            })?;
-
-        info!("Parent image has been created!");
-
-        Ok(result)
+#[async_trait::async_trait]
+impl<'a> QemuParentImageBuilder<'a> for ParentImageBuilder<'a> {
+    fn parent_image_builder(&self) -> &GenericParentImageBuilder<'a> {
+        &self.parent_image_builder
     }
 
-    fn create_requisites(
-        &self,
-        build_context: &BuildContext,
-        copy_dependencies: &[String],
-    ) -> std::result::Result<(), String> {
-        let docker_file = self.docker_file_contents(copy_dependencies.to_vec());
-
-        build_context.create_docker_file(&docker_file)?;
-
-        build_context.create_resources(GenericParentImageBuilder::IMAGE_BUILD_DEPENDENCIES)?;
-
-        let startup_script_path = build_context
-            .path()
-            .join(GenericParentImageBuilder::STARTUP_SCRIPT_NAME);
-
-        self.parent_image_builder
-            .append_start_enclave_command(&startup_script_path)?;
-
-        if cfg!(debug_assertions) {
-            file::log_file(&startup_script_path)?;
-        }
-
-        Ok(())
+    fn cpu_count(&self) -> u8 {
+        self.start_options.cpu_count
     }
 
-    fn docker_file_contents(&self, items: Vec<String>) -> DockerFile {
-        let add = DockerCopyArgs {
-            items,
-            destination: INSTALLATION_DIR.to_string() + "/",
-        };
-
-        let run_parent_cmd = Path::new(INSTALLATION_DIR)
-            .join("start-parent.sh")
-            .display()
-            .to_string();
-
-        let log_env = rust_log_env_var("parent");
-        let cpu_count_env = self.cpu_count_env_var();
-        let mem_size_env = self.mem_size_env_var();
-        let eos_debug_env = GenericParentImageBuilder::eos_debug_env_var();
-
-        let env_vars = vec![log_env, cpu_count_env, mem_size_env, eos_debug_env];
-
-        let abs_orig_env_list_path = Path::new(INSTALLATION_DIR)
-            .join(ORIG_ENV_LIST_PATH)
-            .display()
-            .to_string();
-        let save_envs_run_command = format!("printenv > {}", abs_orig_env_list_path);
-
-        let from = self.parent_image_builder.parent_image.clone();
-
-        DockerFile {
-            from,
-            add: Some(add),
-            env: env_vars,
-            run: Some(save_envs_run_command),
-            cmd: None,
-            entrypoint: Some(vec![
-                run_parent_cmd,
-                "--platform".to_string(),
-                "simulator".to_string(),
-            ]),
-        }
+    fn mem_size(&self) -> &Option<api_model::ByteUnit> {
+        &self.start_options.mem_size
     }
 
-    fn cpu_count_env_var(&self) -> String {
-        let cpu_count = if self.start_options.cpu_count == 0 {
-            GenericParentImageBuilder::DEFAULT_CPU_COUNT
-        } else {
-            self.start_options.cpu_count
-        };
-        format!("CPU_COUNT={}", cpu_count)
+    fn enable_gpu_passthrough(&self) -> Option<bool> {
+        None
     }
 
-    fn mem_size_env_var(&self) -> String {
-        format!(
-            "MEM_SIZE={}",
-            self.start_options
-                .mem_size
-                .as_ref()
-                .map(|e| e.to_mb())
-                .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE)
-        )
+    fn platform_name(&self) -> &'static str {
+        "simulator"
     }
 
-    // Moves blobs located at system to build context and returns filenames only.
-    fn move_blobs_into_build_context(&self, build_context: &BuildContext) -> Result<Vec<String>> {
-        let blobs = self.collect_blob_paths()?;
-        let mut filenames = Vec::with_capacity(blobs.len());
-
-        for blob in blobs {
-            let filename = blob
-                .file_name()
-                .and_then(|f| f.to_str())
-                .ok_or(ConverterError {
-                    message: format!("Invalid path: {}", blob.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                })?;
-
-            let dest = build_context.path().join(filename);
-            move_file(blob.as_path(), &dest)?;
-            filenames.push(filename.to_owned());
-        }
-
-        Ok(filenames)
+    fn initramfs_filename(&self) -> &'static str {
+        SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME
     }
 
     fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
+        use crate::image_builder::INSTALLATION_DIR;
+        use crate::{ConverterError, ConverterErrorKind};
         let mut ret = Vec::new();
 
-        let kernel_path = Path::new(INSTALLATION_DIR).join("blobs").join("kernel");
+        let kernel_path = Path::new(INSTALLATION_DIR).join("blobs").join("bzImage");
         if !kernel_path.exists() {
             return Err(ConverterError {
                 message: format!(

--- a/tools/container-converter/src/image_builder/parent/simulator.rs
+++ b/tools/container-converter/src/image_builder/parent/simulator.rs
@@ -58,6 +58,11 @@ impl<'a> QemuParentImageBuilder<'a> for ParentImageBuilder<'a> {
         SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME
     }
 
+    // Not used in simulator mode
+    fn ovmf_filename(&self) -> &'static str {
+        ""
+    }
+
     fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
         use crate::image_builder::INSTALLATION_DIR;
         use crate::{ConverterError, ConverterErrorKind};

--- a/tools/container-converter/src/image_builder/parent/snp.rs
+++ b/tools/container-converter/src/image_builder/parent/snp.rs
@@ -4,25 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::path::{Path, PathBuf};
-
 use api_model::snp::SNPEnclavesConversionRequestOptions;
 use docker_image_reference::Reference as DockerReference;
-use log::info;
 
 use crate::docker::DockerUtil;
-use crate::file::{BuildContext, DockerCopyArgs, DockerFile};
 use crate::image::ImageWithDetails;
 use crate::image_builder::enclave::snp::EnclaveImageBuilder as SnpEnclaveImageBuilder;
-use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::image_builder::parent::ParentImageBuilder as GenericParentImageBuilder;
-use crate::image_builder::{rust_log_env_var, INSTALLATION_DIR, ORIG_ENV_LIST_PATH};
-use crate::{file, ConverterError, ConverterErrorKind, Result};
+use crate::Result;
 
-use super::move_file;
-
-pub(crate) const BLOBS_SUBDIR_GPU_ENABLED: &'static str = "kernel_enabled_gpu";
-pub(crate) const BLOBS_SUBDIR_GPU_DISABLED: &'static str = "kernel_disabled_gpu";
+use super::qemu::QemuParentImageBuilder;
 
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
@@ -30,215 +21,42 @@ pub(crate) struct ParentImageBuilder<'a> {
 }
 
 impl<'a> ParentImageBuilder<'a> {
-    pub(crate) const IMAGE_COPY_DEPENDENCIES: &'static [&'static str] = &[
-        GenericParentImageBuilder::STARTUP_SCRIPT_NAME,
-        GenericParentImageBuilder::BINARY_NAME,
-        SnpEnclaveImageBuilder::INITRAMFS_FILENAME,
-        GenericEnclaveImageBuilder::BLOCK_FILE_OUT,
-    ];
-
     pub(crate) async fn create_image(
         &self,
         docker_util: &dyn DockerUtil,
         image_reference: DockerReference<'a>,
     ) -> Result<ImageWithDetails<'a>> {
-        let build_context =
-            BuildContext::new(&self.parent_image_builder.dir.path()).map_err(|message| {
-                ConverterError {
-                    message,
-                    kind: ConverterErrorKind::RequisitesCreation,
-                }
-            })?;
+        QemuParentImageBuilder::create_image(self, docker_util, image_reference).await
+    }
+}
 
-        // Move initramfs build by enclave image builder to build context.
-        self.parent_image_builder
-            .move_enclave_files_into_build_context(
-                build_context.path(),
-                SnpEnclaveImageBuilder::INITRAMFS_FILENAME,
-            )?;
-
-        let blob_filenames = self.move_blobs_into_build_context(&build_context)?;
-        let mut copy_dependencies: Vec<String> = Self::IMAGE_COPY_DEPENDENCIES
-            .iter()
-            .map(|e| e.to_string())
-            .collect();
-        copy_dependencies.extend(blob_filenames);
-
-        self.create_requisites(&build_context, &copy_dependencies)
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-        info!("Parent prerequisites have been created!");
-
-        let build_context_archive_file = build_context
-            .package_into_archive(
-                &self
-                    .parent_image_builder
-                    .dir
-                    .path()
-                    .join("parent-build-context.tar"),
-            )
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-
-        let result = docker_util
-            .create_image_from_archive(image_reference, build_context_archive_file)
-            .await
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::ParentImageCreation,
-            })?;
-
-        info!("Parent image has been created!");
-
-        Ok(result)
+#[async_trait::async_trait]
+impl<'a> QemuParentImageBuilder<'a> for ParentImageBuilder<'a> {
+    fn parent_image_builder(&self) -> &GenericParentImageBuilder<'a> {
+        &self.parent_image_builder
     }
 
-    fn create_requisites(
-        &self,
-        build_context: &BuildContext,
-        copy_dependencies: &[String],
-    ) -> std::result::Result<(), String> {
-        let docker_file = self.docker_file_contents(copy_dependencies.to_vec());
-
-        build_context.create_docker_file(&docker_file)?;
-
-        build_context.create_resources(GenericParentImageBuilder::IMAGE_BUILD_DEPENDENCIES)?;
-
-        let startup_script_path = build_context
-            .path()
-            .join(GenericParentImageBuilder::STARTUP_SCRIPT_NAME);
-
-        self.parent_image_builder
-            .append_start_enclave_command(&startup_script_path)?;
-
-        if cfg!(debug_assertions) {
-            file::log_file(&startup_script_path)?;
-        }
-
-        Ok(())
+    fn cpu_count(&self) -> u8 {
+        self.start_options.cpu_count
     }
 
-    fn docker_file_contents(&self, items: Vec<String>) -> DockerFile {
-        let add = DockerCopyArgs {
-            items,
-            destination: INSTALLATION_DIR.to_string() + "/",
-        };
-
-        let run_parent_cmd = Path::new(INSTALLATION_DIR)
-            .join("start-parent.sh")
-            .display()
-            .to_string();
-
-        let log_env = rust_log_env_var("parent");
-        let cpu_count_env = self.cpu_count_env_var();
-        let mem_size_env = self.mem_size_env_var();
-        let eos_debug_env = GenericParentImageBuilder::eos_debug_env_var();
-
-        let env_vars = vec![log_env, cpu_count_env, mem_size_env, eos_debug_env];
-
-        let abs_orig_env_list_path = Path::new(INSTALLATION_DIR)
-            .join(ORIG_ENV_LIST_PATH)
-            .display()
-            .to_string();
-        let save_envs_run_command = format!("printenv > {}", abs_orig_env_list_path);
-
-        let from = self.parent_image_builder.parent_image.clone();
-
-        DockerFile {
-            from,
-            add: Some(add),
-            env: env_vars,
-            run: Some(save_envs_run_command),
-            cmd: None,
-            entrypoint: Some(vec![
-                run_parent_cmd,
-                "--platform".to_string(),
-                "snp".to_string(),
-            ]),
-        }
+    fn mem_size(&self) -> &Option<api_model::ByteUnit> {
+        &self.start_options.mem_size
     }
 
-    fn cpu_count_env_var(&self) -> String {
-        let cpu_count = if self.start_options.cpu_count == 0 {
-            GenericParentImageBuilder::DEFAULT_CPU_COUNT
-        } else {
-            self.start_options.cpu_count
-        };
-        format!("CPU_COUNT={}", cpu_count)
+    fn enable_gpu_passthrough(&self) -> Option<bool> {
+        self.start_options.enable_gpu_passthrough
     }
 
-    fn mem_size_env_var(&self) -> String {
-        format!(
-            "MEM_SIZE={}",
-            self.start_options
-                .mem_size
-                .as_ref()
-                .map(|e| e.to_mb())
-                .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE)
-        )
+    fn platform_name(&self) -> &'static str {
+        "snp"
     }
 
-    // Moves blobs located at system to build context and returns filenames only
-    fn move_blobs_into_build_context(&self, build_context: &BuildContext) -> Result<Vec<String>> {
-        let blobs = self.collect_blob_paths()?;
-        let mut filenames = Vec::with_capacity(blobs.len());
-        for blob in blobs {
-            let filename = blob
-                .file_name()
-                .and_then(|f| f.to_str())
-                .ok_or(ConverterError {
-                    message: format!("Invalid path: {}", blob.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                })?;
-            let dest = build_context.path().join(filename);
-            move_file(blob.as_path(), &dest)?;
-            filenames.push(filename.to_owned());
-        }
-
-        Ok(filenames)
+    fn initramfs_filename(&self) -> &'static str {
+        SnpEnclaveImageBuilder::INITRAMFS_FILENAME
     }
 
-    fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
-        let mut ret = Vec::new();
-        let mut blobs_dir = PathBuf::from(format!("{}/blobs", INSTALLATION_DIR));
-
-        {
-            blobs_dir.push("OVMF.amdsev.fd");
-            let blob_path = blobs_dir.clone();
-            if !blob_path.exists() {
-                return Err(ConverterError {
-                    message: format!("OVMF file could not be found at: {}", blob_path.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                });
-            }
-            ret.push(blob_path);
-            blobs_dir.pop();
-        }
-
-        if self.start_options.enable_gpu_passthrough.unwrap_or(false) {
-            blobs_dir.push(BLOBS_SUBDIR_GPU_ENABLED);
-        } else {
-            blobs_dir.push(BLOBS_SUBDIR_GPU_DISABLED);
-        }
-
-        let kernel_blobs = vec!["bzImage", "bzImage.config"];
-        for blob in kernel_blobs {
-            blobs_dir.push(blob);
-            let blob_path = blobs_dir.clone();
-            if !blob_path.exists() {
-                return Err(ConverterError {
-                    message: format!("Blob {} could not be found!", blob_path.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                });
-            }
-            ret.push(blob_path);
-            blobs_dir.pop();
-        }
-
-        Ok(ret)
+    fn ovmf_filename(&self) -> &'static str {
+        SnpEnclaveImageBuilder::OVMF_FILENAME
     }
 }

--- a/tools/container-converter/src/image_builder/parent/snp.rs
+++ b/tools/container-converter/src/image_builder/parent/snp.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api_model::snp::SNPEnclavesConversionRequestOptions;
+use api_model::EnclavesOptions;
 use docker_image_reference::Reference as DockerReference;
 
 use crate::docker::DockerUtil;
@@ -17,7 +17,7 @@ use super::qemu::QemuParentImageBuilder;
 
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
-    pub(crate) start_options: SNPEnclavesConversionRequestOptions,
+    pub(crate) start_options: EnclavesOptions,
 }
 
 impl<'a> ParentImageBuilder<'a> {

--- a/tools/container-converter/src/image_builder/parent/tdx.rs
+++ b/tools/container-converter/src/image_builder/parent/tdx.rs
@@ -6,14 +6,14 @@
 
 use std::path::{Path, PathBuf};
 
-use api_model::simulator::SimulatorEnclavesConversionRequestOptions;
+use api_model::tdx::TDXEnclavesConversionRequestOptions;
 use docker_image_reference::Reference as DockerReference;
 use log::info;
 
 use crate::docker::DockerUtil;
 use crate::file::{BuildContext, DockerCopyArgs, DockerFile};
 use crate::image::ImageWithDetails;
-use crate::image_builder::enclave::simulator::EnclaveImageBuilder as SimulatorEnclaveImageBuilder;
+use crate::image_builder::enclave::tdx::EnclaveImageBuilder as TdxEnclaveImageBuilder;
 use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::image_builder::parent::ParentImageBuilder as GenericParentImageBuilder;
 use crate::image_builder::{rust_log_env_var, INSTALLATION_DIR, ORIG_ENV_LIST_PATH};
@@ -21,16 +21,19 @@ use crate::{file, ConverterError, ConverterErrorKind, Result};
 
 use super::move_file;
 
+pub(crate) const BLOBS_SUBDIR_GPU_ENABLED: &'static str = "kernel_enabled_gpu";
+pub(crate) const BLOBS_SUBDIR_GPU_DISABLED: &'static str = "kernel_disabled_gpu";
+
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
-    pub(crate) start_options: SimulatorEnclavesConversionRequestOptions,
+    pub(crate) start_options: TDXEnclavesConversionRequestOptions,
 }
 
 impl<'a> ParentImageBuilder<'a> {
     pub(crate) const IMAGE_COPY_DEPENDENCIES: &'static [&'static str] = &[
         GenericParentImageBuilder::STARTUP_SCRIPT_NAME,
         GenericParentImageBuilder::BINARY_NAME,
-        SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME,
+        TdxEnclaveImageBuilder::INITRAMFS_FILENAME,
         GenericEnclaveImageBuilder::BLOCK_FILE_OUT,
     ];
 
@@ -47,11 +50,11 @@ impl<'a> ParentImageBuilder<'a> {
                 }
             })?;
 
-        // Move initramfs built by enclave image builder to build context.
+        // Move initramfs build by enclave image builder to build context.
         self.parent_image_builder
             .move_enclave_files_into_build_context(
                 build_context.path(),
-                SimulatorEnclaveImageBuilder::INITRAMFS_FILENAME,
+                TdxEnclaveImageBuilder::INITRAMFS_FILENAME,
             )?;
 
         let blob_filenames = self.move_blobs_into_build_context(&build_context)?;
@@ -154,7 +157,7 @@ impl<'a> ParentImageBuilder<'a> {
             entrypoint: Some(vec![
                 run_parent_cmd,
                 "--platform".to_string(),
-                "simulator".to_string(),
+                "tdx".to_string(),
             ]),
         }
     }
@@ -179,11 +182,10 @@ impl<'a> ParentImageBuilder<'a> {
         )
     }
 
-    // Moves blobs located at system to build context and returns filenames only.
+    // Moves blobs located at system to build context and returns filenames only
     fn move_blobs_into_build_context(&self, build_context: &BuildContext) -> Result<Vec<String>> {
         let blobs = self.collect_blob_paths()?;
         let mut filenames = Vec::with_capacity(blobs.len());
-
         for blob in blobs {
             let filename = blob
                 .file_name()
@@ -192,7 +194,6 @@ impl<'a> ParentImageBuilder<'a> {
                     message: format!("Invalid path: {}", blob.display()),
                     kind: ConverterErrorKind::RequisitesCreation,
                 })?;
-
             let dest = build_context.path().join(filename);
             move_file(blob.as_path(), &dest)?;
             filenames.push(filename.to_owned());
@@ -203,19 +204,40 @@ impl<'a> ParentImageBuilder<'a> {
 
     fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
         let mut ret = Vec::new();
+        let mut blobs_dir = PathBuf::from(format!("{}/blobs", INSTALLATION_DIR));
 
-        let kernel_path = Path::new(INSTALLATION_DIR).join("blobs").join("kernel");
-        if !kernel_path.exists() {
-            return Err(ConverterError {
-                message: format!(
-                    "Simulator kernel could not be found at: {}",
-                    kernel_path.display()
-                ),
-                kind: ConverterErrorKind::RequisitesCreation,
-            });
+        {
+            blobs_dir.push("OVMF.amdsev.fd");
+            let blob_path = blobs_dir.clone();
+            if !blob_path.exists() {
+                return Err(ConverterError {
+                    message: format!("OVMF file could not be found at: {}", blob_path.display()),
+                    kind: ConverterErrorKind::RequisitesCreation,
+                });
+            }
+            ret.push(blob_path);
+            blobs_dir.pop();
         }
 
-        ret.push(kernel_path);
+        if self.start_options.enable_gpu_passthrough.unwrap_or(false) {
+            blobs_dir.push(BLOBS_SUBDIR_GPU_ENABLED);
+        } else {
+            blobs_dir.push(BLOBS_SUBDIR_GPU_DISABLED);
+        }
+
+        let kernel_blobs = vec!["bzImage", "bzImage.config"];
+        for blob in kernel_blobs {
+            blobs_dir.push(blob);
+            let blob_path = blobs_dir.clone();
+            if !blob_path.exists() {
+                return Err(ConverterError {
+                    message: format!("Blob {} could not be found!", blob_path.display()),
+                    kind: ConverterErrorKind::RequisitesCreation,
+                });
+            }
+            ret.push(blob_path);
+            blobs_dir.pop();
+        }
 
         Ok(ret)
     }

--- a/tools/container-converter/src/image_builder/parent/tdx.rs
+++ b/tools/container-converter/src/image_builder/parent/tdx.rs
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use api_model::tdx::TDXEnclavesConversionRequestOptions;
+use api_model::EnclavesOptions;
 use docker_image_reference::Reference as DockerReference;
 
 use crate::docker::DockerUtil;
@@ -17,7 +17,7 @@ use super::qemu::QemuParentImageBuilder;
 
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
-    pub(crate) start_options: TDXEnclavesConversionRequestOptions,
+    pub(crate) start_options: EnclavesOptions,
 }
 
 impl<'a> ParentImageBuilder<'a> {

--- a/tools/container-converter/src/image_builder/parent/tdx.rs
+++ b/tools/container-converter/src/image_builder/parent/tdx.rs
@@ -4,25 +4,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::path::{Path, PathBuf};
-
 use api_model::tdx::TDXEnclavesConversionRequestOptions;
 use docker_image_reference::Reference as DockerReference;
-use log::info;
 
 use crate::docker::DockerUtil;
-use crate::file::{BuildContext, DockerCopyArgs, DockerFile};
 use crate::image::ImageWithDetails;
 use crate::image_builder::enclave::tdx::EnclaveImageBuilder as TdxEnclaveImageBuilder;
-use crate::image_builder::enclave::GenericEnclaveImageBuilder;
 use crate::image_builder::parent::ParentImageBuilder as GenericParentImageBuilder;
-use crate::image_builder::{rust_log_env_var, INSTALLATION_DIR, ORIG_ENV_LIST_PATH};
-use crate::{file, ConverterError, ConverterErrorKind, Result};
+use crate::Result;
 
-use super::move_file;
-
-pub(crate) const BLOBS_SUBDIR_GPU_ENABLED: &'static str = "kernel_enabled_gpu";
-pub(crate) const BLOBS_SUBDIR_GPU_DISABLED: &'static str = "kernel_disabled_gpu";
+use super::qemu::QemuParentImageBuilder;
 
 pub(crate) struct ParentImageBuilder<'a> {
     pub(crate) parent_image_builder: crate::image_builder::parent::ParentImageBuilder<'a>,
@@ -30,215 +21,42 @@ pub(crate) struct ParentImageBuilder<'a> {
 }
 
 impl<'a> ParentImageBuilder<'a> {
-    pub(crate) const IMAGE_COPY_DEPENDENCIES: &'static [&'static str] = &[
-        GenericParentImageBuilder::STARTUP_SCRIPT_NAME,
-        GenericParentImageBuilder::BINARY_NAME,
-        TdxEnclaveImageBuilder::INITRAMFS_FILENAME,
-        GenericEnclaveImageBuilder::BLOCK_FILE_OUT,
-    ];
-
     pub(crate) async fn create_image(
         &self,
         docker_util: &dyn DockerUtil,
         image_reference: DockerReference<'a>,
     ) -> Result<ImageWithDetails<'a>> {
-        let build_context =
-            BuildContext::new(&self.parent_image_builder.dir.path()).map_err(|message| {
-                ConverterError {
-                    message,
-                    kind: ConverterErrorKind::RequisitesCreation,
-                }
-            })?;
+        QemuParentImageBuilder::create_image(self, docker_util, image_reference).await
+    }
+}
 
-        // Move initramfs build by enclave image builder to build context.
-        self.parent_image_builder
-            .move_enclave_files_into_build_context(
-                build_context.path(),
-                TdxEnclaveImageBuilder::INITRAMFS_FILENAME,
-            )?;
-
-        let blob_filenames = self.move_blobs_into_build_context(&build_context)?;
-        let mut copy_dependencies: Vec<String> = Self::IMAGE_COPY_DEPENDENCIES
-            .iter()
-            .map(|e| e.to_string())
-            .collect();
-        copy_dependencies.extend(blob_filenames);
-
-        self.create_requisites(&build_context, &copy_dependencies)
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-        info!("Parent prerequisites have been created!");
-
-        let build_context_archive_file = build_context
-            .package_into_archive(
-                &self
-                    .parent_image_builder
-                    .dir
-                    .path()
-                    .join("parent-build-context.tar"),
-            )
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::RequisitesCreation,
-            })?;
-
-        let result = docker_util
-            .create_image_from_archive(image_reference, build_context_archive_file)
-            .await
-            .map_err(|message| ConverterError {
-                message,
-                kind: ConverterErrorKind::ParentImageCreation,
-            })?;
-
-        info!("Parent image has been created!");
-
-        Ok(result)
+#[async_trait::async_trait]
+impl<'a> QemuParentImageBuilder<'a> for ParentImageBuilder<'a> {
+    fn parent_image_builder(&self) -> &GenericParentImageBuilder<'a> {
+        &self.parent_image_builder
     }
 
-    fn create_requisites(
-        &self,
-        build_context: &BuildContext,
-        copy_dependencies: &[String],
-    ) -> std::result::Result<(), String> {
-        let docker_file = self.docker_file_contents(copy_dependencies.to_vec());
-
-        build_context.create_docker_file(&docker_file)?;
-
-        build_context.create_resources(GenericParentImageBuilder::IMAGE_BUILD_DEPENDENCIES)?;
-
-        let startup_script_path = build_context
-            .path()
-            .join(GenericParentImageBuilder::STARTUP_SCRIPT_NAME);
-
-        self.parent_image_builder
-            .append_start_enclave_command(&startup_script_path)?;
-
-        if cfg!(debug_assertions) {
-            file::log_file(&startup_script_path)?;
-        }
-
-        Ok(())
+    fn cpu_count(&self) -> u8 {
+        self.start_options.cpu_count
     }
 
-    fn docker_file_contents(&self, items: Vec<String>) -> DockerFile {
-        let add = DockerCopyArgs {
-            items,
-            destination: INSTALLATION_DIR.to_string() + "/",
-        };
-
-        let run_parent_cmd = Path::new(INSTALLATION_DIR)
-            .join("start-parent.sh")
-            .display()
-            .to_string();
-
-        let log_env = rust_log_env_var("parent");
-        let cpu_count_env = self.cpu_count_env_var();
-        let mem_size_env = self.mem_size_env_var();
-        let eos_debug_env = GenericParentImageBuilder::eos_debug_env_var();
-
-        let env_vars = vec![log_env, cpu_count_env, mem_size_env, eos_debug_env];
-
-        let abs_orig_env_list_path = Path::new(INSTALLATION_DIR)
-            .join(ORIG_ENV_LIST_PATH)
-            .display()
-            .to_string();
-        let save_envs_run_command = format!("printenv > {}", abs_orig_env_list_path);
-
-        let from = self.parent_image_builder.parent_image.clone();
-
-        DockerFile {
-            from,
-            add: Some(add),
-            env: env_vars,
-            run: Some(save_envs_run_command),
-            cmd: None,
-            entrypoint: Some(vec![
-                run_parent_cmd,
-                "--platform".to_string(),
-                "tdx".to_string(),
-            ]),
-        }
+    fn mem_size(&self) -> &Option<api_model::ByteUnit> {
+        &self.start_options.mem_size
     }
 
-    fn cpu_count_env_var(&self) -> String {
-        let cpu_count = if self.start_options.cpu_count == 0 {
-            GenericParentImageBuilder::DEFAULT_CPU_COUNT
-        } else {
-            self.start_options.cpu_count
-        };
-        format!("CPU_COUNT={}", cpu_count)
+    fn enable_gpu_passthrough(&self) -> Option<bool> {
+        self.start_options.enable_gpu_passthrough
     }
 
-    fn mem_size_env_var(&self) -> String {
-        format!(
-            "MEM_SIZE={}",
-            self.start_options
-                .mem_size
-                .as_ref()
-                .map(|e| e.to_mb())
-                .unwrap_or(GenericParentImageBuilder::DEFAULT_MEMORY_SIZE)
-        )
+    fn platform_name(&self) -> &'static str {
+        "tdx"
     }
 
-    // Moves blobs located at system to build context and returns filenames only
-    fn move_blobs_into_build_context(&self, build_context: &BuildContext) -> Result<Vec<String>> {
-        let blobs = self.collect_blob_paths()?;
-        let mut filenames = Vec::with_capacity(blobs.len());
-        for blob in blobs {
-            let filename = blob
-                .file_name()
-                .and_then(|f| f.to_str())
-                .ok_or(ConverterError {
-                    message: format!("Invalid path: {}", blob.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                })?;
-            let dest = build_context.path().join(filename);
-            move_file(blob.as_path(), &dest)?;
-            filenames.push(filename.to_owned());
-        }
-
-        Ok(filenames)
+    fn initramfs_filename(&self) -> &'static str {
+        TdxEnclaveImageBuilder::INITRAMFS_FILENAME
     }
 
-    fn collect_blob_paths(&self) -> Result<Vec<PathBuf>> {
-        let mut ret = Vec::new();
-        let mut blobs_dir = PathBuf::from(format!("{}/blobs", INSTALLATION_DIR));
-
-        {
-            blobs_dir.push("OVMF.amdsev.fd");
-            let blob_path = blobs_dir.clone();
-            if !blob_path.exists() {
-                return Err(ConverterError {
-                    message: format!("OVMF file could not be found at: {}", blob_path.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                });
-            }
-            ret.push(blob_path);
-            blobs_dir.pop();
-        }
-
-        if self.start_options.enable_gpu_passthrough.unwrap_or(false) {
-            blobs_dir.push(BLOBS_SUBDIR_GPU_ENABLED);
-        } else {
-            blobs_dir.push(BLOBS_SUBDIR_GPU_DISABLED);
-        }
-
-        let kernel_blobs = vec!["bzImage", "bzImage.config"];
-        for blob in kernel_blobs {
-            blobs_dir.push(blob);
-            let blob_path = blobs_dir.clone();
-            if !blob_path.exists() {
-                return Err(ConverterError {
-                    message: format!("Blob {} could not be found!", blob_path.display()),
-                    kind: ConverterErrorKind::RequisitesCreation,
-                });
-            }
-            ret.push(blob_path);
-            blobs_dir.pop();
-        }
-
-        Ok(ret)
+    fn ovmf_filename(&self) -> &'static str {
+        TdxEnclaveImageBuilder::OVMF_FILENAME
     }
 }

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -98,7 +98,7 @@ impl Error for ConverterError {}
 #[cfg(platform = "nitro")]
 const PARENT_IMAGE: &str = "parent-base-nitro";
 
-#[cfg(any(platform = "snp", platform = "tdx"))]
+#[cfg(platform = "snp")]
 const PARENT_IMAGE: &str = "parent-base-snp";
 #[cfg(platform = "tdx")]
 const PARENT_IMAGE: &str = "parent-base-tdx";

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -9,6 +9,8 @@ pub mod nitro;
 pub mod simulator;
 #[cfg(platform = "snp")]
 pub mod snp;
+#[cfg(platform = "tdx")]
+pub mod tdx;
 
 use std::collections::HashSet;
 use std::error::Error;
@@ -45,6 +47,8 @@ use crate::nitro::create_response;
 
 #[cfg(platform = "snp")]
 use crate::snp::create_response;
+#[cfg(platform = "tdx")]
+use crate::tdx::create_response;
 
 #[cfg(platform = "simulator")]
 use crate::simulator::create_response;
@@ -96,6 +100,8 @@ const PARENT_IMAGE: &str = "parent-base-nitro";
 
 #[cfg(any(platform = "snp", platform = "tdx"))]
 const PARENT_IMAGE: &str = "parent-base-snp";
+#[cfg(platform = "tdx")]
+const PARENT_IMAGE: &str = "parent-base-tdx";
 
 #[cfg(platform = "simulator")]
 const PARENT_IMAGE: &str = "parent-base-simulator";
@@ -108,8 +114,10 @@ const ENCLAVE_IMAGE: &str = "enclave-base";
 #[cfg(platform = "simulator")]
 const ENCLAVE_IMAGE: &str = "enclave-base-simulator";
 
-#[cfg(any(platform = "snp", platform = "tdx"))]
-const ENCLAVE_IMAGE_SNP_GPU: &str = "enclave-base-gpu";
+#[cfg(platform = "snp")]
+const ENCLAVE_IMAGE_SNP_GPU: &str = "enclave-base-snp-gpu";
+#[cfg(platform = "tdx")]
+const ENCLAVE_IMAGE_TDX_GPU: &str = "enclave-base-tdx-gpu";
 
 const ENCLAVE_IMAGE_PATH: &str = "enclave-base.tar";
 
@@ -224,7 +232,7 @@ async fn run0(
         let enclave_settings = EnclaveSettings::new(
             &input_image,
             &conversion_request.request.converter_options,
-            #[cfg(platform = "snp")]
+            #[cfg(any(platform = "snp", platform = "tdx"))]
             &conversion_request.enclaves_options,
         );
         let image_env_vars =

--- a/tools/container-converter/src/main.rs
+++ b/tools/container-converter/src/main.rs
@@ -15,6 +15,8 @@ use container_converter::nitro as platform;
 use container_converter::simulator as platform;
 #[cfg(platform = "snp")]
 use container_converter::snp as platform;
+#[cfg(platform = "tdx")]
+use container_converter::tdx as platform;
 
 static ABOUT: LazyLock<String> = LazyLock::new(|| {
     format!(

--- a/tools/container-converter/src/resources/parent/start-parent.sh
+++ b/tools/container-converter/src/resources/parent/start-parent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is an entry point script for parent image.
-# Its main purpose is to setup env vars for nitro/snp/simulator tooling and pre-setup networking.
+# Its main purpose is to setup env vars for nitro/snp/tdx/simulator tooling and pre-setup networking.
 # Enclave start and connection code is applied dynamically to the bottom of this file by the converter.
 
 # Allow job control in interactive mode. This is used by the code that is
@@ -8,23 +8,25 @@
 set -em
 
 PLATFORM="nitro"
+PLATFORMS=("nitro" "simulator" "snp" "tdx")
 
 show_help() {
     echo "Usage: $0 [options]"
     echo ""
     echo "Options:"
-    echo "  --platform PLATFORM  Target platform: 'snp', 'simulator', or 'nitro' (default: nitro)"
+    echo "  --platform PLATFORM  Target platform: 'snp', 'tdx', 'simulator', or 'nitro' (default: nitro)"
     echo "  --help               Show this help message"
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --platform)
-            if [[ "$2" == "snp" || "$2" == "simulator" || "$2" == "nitro" ]]; then
+            pattern=" ${2} "
+            if [[ " ${PLATFORMS[*]} " =~ $pattern ]]; then
                 PLATFORM="$2"
                 shift 2
             else
-                echo "Error: Invalid platform '$2'. Must be 'snp', 'simulator', or 'nitro'."
+                echo "Error: Invalid platform '$2'. Must be 'snp', 'tdx', 'simulator', or 'nitro'."
                 show_help
                 exit 1
             fi
@@ -46,8 +48,8 @@ done
 if [ "$PLATFORM" == "nitro" ]; then
     # Check if nitro-cli is properly installed
     nitro-cli --version
-elif [ "$PLATFORM" == "snp" ] || [ "$PLATFORM" == "simulator" ]; then
-    # Check if qemu is properly installed
+else
+    # Check if qemu is properly installed for the rest of platforms
     qemu-system-x86_64 --version
 fi
 

--- a/tools/container-converter/src/tdx.rs
+++ b/tools/container-converter/src/tdx.rs
@@ -6,8 +6,8 @@
 
 use api_model::{
     converter::ConvertedImageInfo,
+    tdx::{TDXEnclaveConfig, TDXEnclaveMeasurements},
     PlatformConversionResponse,
-    tdx::{TDXEnclaveMeasurements, TDXEnclaveConfig},
 };
 
 use crate::{hex_response, image::ImageWithDetails, Result};

--- a/tools/container-converter/src/tdx.rs
+++ b/tools/container-converter/src/tdx.rs
@@ -1,0 +1,30 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use api_model::{
+    converter::ConvertedImageInfo,
+    tdx::{TDXEnclavesConfig, TDXEnclavesConversionResponse, TDXEnclavesMeasurements},
+};
+
+use crate::{hex_response, image::ImageWithDetails, Result};
+
+pub const NAME: &str = "Intel TDX";
+
+pub(crate) fn create_response(
+    image: &ImageWithDetails,
+    measurements: TDXEnclavesMeasurements,
+) -> Result<TDXEnclavesConversionResponse> {
+    let result = TDXEnclavesConversionResponse {
+        converted_image: ConvertedImageInfo {
+            name: image.reference.to_string(),
+            sha: hex_response(image.short_id())?,
+            size: image.details.size as usize,
+        },
+
+        config: TDXEnclavesConfig { measurements },
+    };
+    Ok(result)
+}

--- a/tools/container-converter/src/tdx.rs
+++ b/tools/container-converter/src/tdx.rs
@@ -6,7 +6,8 @@
 
 use api_model::{
     converter::ConvertedImageInfo,
-    tdx::{TDXEnclavesConfig, TDXEnclavesConversionResponse, TDXEnclavesMeasurements},
+    PlatformConversionResponse,
+    tdx::{TDXEnclaveMeasurements, TDXEnclaveConfig},
 };
 
 use crate::{hex_response, image::ImageWithDetails, Result};
@@ -15,16 +16,16 @@ pub const NAME: &str = "Intel TDX";
 
 pub(crate) fn create_response(
     image: &ImageWithDetails,
-    measurements: TDXEnclavesMeasurements,
-) -> Result<TDXEnclavesConversionResponse> {
-    let result = TDXEnclavesConversionResponse {
+    measurements: TDXEnclaveMeasurements,
+) -> Result<PlatformConversionResponse> {
+    let result = PlatformConversionResponse {
         converted_image: ConvertedImageInfo {
             name: image.reference.to_string(),
             sha: hex_response(image.short_id())?,
             size: image.details.size as usize,
         },
 
-        config: TDXEnclavesConfig { measurements },
+        config: TDXEnclaveConfig { measurements },
     };
     Ok(result)
 }

--- a/vsock-proxy/parent/src/platform/simulator.rs
+++ b/vsock-proxy/parent/src/platform/simulator.rs
@@ -6,7 +6,7 @@
 use super::{GuestLaunchResult, GuestTasks};
 use crate::platform::qemu::{constants, env_or_default, QemuPlatform};
 
-const DEFAULT_MEMORY_SIZE: &str = "2048";
+const DEFAULT_MEMORY_SIZE: &str = "2048M";
 
 struct SimulatorPlatform;
 
@@ -25,7 +25,7 @@ impl QemuPlatform for SimulatorPlatform {
 
     // Simulator is mostly used locally; setting a reasonable default.
     fn memory_size(&self) -> String {
-        env_or_default(constants::CPU_COUNT_ENV_VAR, DEFAULT_MEMORY_SIZE)
+        env_or_default(constants::MEM_SIZE_ENV_VAR, DEFAULT_MEMORY_SIZE)
     }
 
     fn machine(&self) -> Option<String> {


### PR DESCRIPTION
This PR adds TDX support to converter-container tool along with various improvements and fixes.

* Introduced qemu enclave image builder trait. All qemu based enclaves such as snp, tdx and simulator uses this trait.
* Introduced qemu parent image builder trait. All qemu based parent image builders uses this trait.
* Fixed simulator mode build.
* Fixed artifact names of simulator mode.
* Fixed serialization error of tdx related api-models.