### PR TITLE
[RTE-1074]: Fix vsock-proxy host device checks.

### DIFF
--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -40,7 +40,6 @@ use crate::network::{
     setup_network_devices, PairedPcapDevice, PairedTapDevice,
 };
 use crate::packet_capture::start_pcap_loops;
-use crate::platform::GuestLaunchResult;
 use crate::ParentConsoleArguments;
 
 const INSTALLATION_DIR: &str = "/opt/fortanix/enclave-os";
@@ -99,25 +98,12 @@ pub(crate) async fn run(args: ParentConsoleArguments) -> Result<UserProgramExitS
     }
 
     info!("Spawning enclave process.");
-    let GuestLaunchResult { enclave_process } = crate::platform::launch_guest();
-    let vsock_stream = create_vsock_stream(VSOCK_PARENT_PORT);
+    let guest_launch_result = crate::platform::launch_guest();
+    // todo: will be used in https://fortanix.atlassian.net/browse/SALM-300
+    let _enclave_process = guest_launch_result.enclave_process;
 
     info!("Awaiting confirmation from enclave.");
-    let mut enclave_port = tokio::select! {
-        res = enclave_process => {
-            match res {
-                Ok(enclave_res) => {
-                    let err_msg = match enclave_res {
-                        Ok(_) => "unexpectedly exited".to_owned(),
-                        Err(err) => err,
-                    };
-                    return Err(format!("Enclave failed: {}", err_msg));
-                }
-                Err(err) => return Err(format!("Unable to join enclave process: {:?}", err)),
-            }
-        }
-        stream_res = vsock_stream => stream_res,
-    }?;
+    let mut enclave_port = create_vsock_stream(VSOCK_PARENT_PORT).await?;
 
     info!("Connected to enclave.");
     // Add enclave processes to a separate list of futures. They will be cleaned up

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -40,6 +40,7 @@ use crate::network::{
     setup_network_devices, PairedPcapDevice, PairedTapDevice,
 };
 use crate::packet_capture::start_pcap_loops;
+use crate::platform::GuestLaunchResult;
 use crate::ParentConsoleArguments;
 
 const INSTALLATION_DIR: &str = "/opt/fortanix/enclave-os";
@@ -98,12 +99,25 @@ pub(crate) async fn run(args: ParentConsoleArguments) -> Result<UserProgramExitS
     }
 
     info!("Spawning enclave process.");
-    let guest_launch_result = crate::platform::launch_guest();
-    // todo: will be used in https://fortanix.atlassian.net/browse/SALM-300
-    let _enclave_process = guest_launch_result.enclave_process;
+    let GuestLaunchResult { enclave_process } = crate::platform::launch_guest();
+    let vsock_stream = create_vsock_stream(VSOCK_PARENT_PORT);
 
     info!("Awaiting confirmation from enclave.");
-    let mut enclave_port = create_vsock_stream(VSOCK_PARENT_PORT).await?;
+    let mut enclave_port = tokio::select! {
+        res = enclave_process => {
+            match res {
+                Ok(enclave_res) => {
+                    let err_msg = match enclave_res {
+                        Ok(_) => "unexpectedly exited".to_owned(),
+                        Err(err) => err,
+                    };
+                    return Err(format!("Enclave failed: {}", err_msg));
+                }
+                Err(err) => return Err(format!("Unable to join enclave process: {:?}", err)),
+            }
+        }
+        stream_res = vsock_stream => stream_res,
+    }?;
 
     info!("Connected to enclave.");
     // Add enclave processes to a separate list of futures. They will be cleaned up

--- a/vsock-proxy/parent/src/platform/qemu.rs
+++ b/vsock-proxy/parent/src/platform/qemu.rs
@@ -33,7 +33,7 @@ pub(super) mod constants {
 
 pub(super) trait QemuPlatform {
     fn firmware_path(&self) -> Option<&'static str>;
-    fn guest_device_path(&self) -> Option<&'static str>;
+    fn host_device_paths(&self) -> Vec<&'static str>;
     fn cpu(&self) -> String;
     fn machine(&self) -> Option<String>;
     fn objects(&self) -> Vec<String>;
@@ -61,8 +61,8 @@ pub(super) trait QemuPlatform {
             require_file("Firmware", firmware_path)?;
         }
 
-        if let Some(guest_dev) = self.guest_device_path() {
-            require_file("Guest device", guest_dev)?;
+        for host_dev in self.host_device_paths() {
+            require_file("Host device", host_dev)?;
         }
 
         Ok(())

--- a/vsock-proxy/parent/src/platform/qemu.rs
+++ b/vsock-proxy/parent/src/platform/qemu.rs
@@ -17,6 +17,7 @@ pub(super) mod constants {
     pub const KERNEL_PATH: &str = "/opt/fortanix/enclave-os/bzImage";
     pub const KERNEL_CMDLINE: &str = "console=ttyS0 rdinit=/init loglevel=7";
     pub const KVM_DEVICE_PATH: &str = "/dev/kvm";
+    pub const VSOCK_HOST_DEVICE_PATH: &str = "/dev/vhost-vsock";
     pub const INITRAMFS_PATH: &str = "/opt/fortanix/enclave-os/initramfs.gz";
 
     pub const IOMMU_DEVICE_PATH: &str = "/dev/iommu";
@@ -33,7 +34,8 @@ pub(super) mod constants {
 
 pub(super) trait QemuPlatform {
     fn firmware_path(&self) -> Option<&'static str>;
-    fn host_device_paths(&self) -> Vec<&'static str>;
+    // Device paths related to confidential-computing
+    fn host_cc_device_paths(&self) -> Vec<&'static str>;
     fn cpu(&self) -> String;
     fn machine(&self) -> Option<String>;
     fn objects(&self) -> Vec<String>;
@@ -51,6 +53,7 @@ pub(super) trait QemuPlatform {
         require_file("Kernel", constants::KERNEL_PATH)?;
         require_file("Initramfs", constants::INITRAMFS_PATH)?;
         require_file("KVM device", constants::KVM_DEVICE_PATH)?;
+        require_file("vhost-vsock device", constants::VSOCK_HOST_DEVICE_PATH)?;
 
         if let Some(gpu) = self.gpu() {
             require_vfio_device(&gpu)?;
@@ -61,7 +64,7 @@ pub(super) trait QemuPlatform {
             require_file("Firmware", firmware_path)?;
         }
 
-        for host_dev in self.host_device_paths() {
+        for host_dev in self.host_cc_device_paths() {
             require_file("Host device", host_dev)?;
         }
 

--- a/vsock-proxy/parent/src/platform/simulator.rs
+++ b/vsock-proxy/parent/src/platform/simulator.rs
@@ -15,7 +15,7 @@ impl QemuPlatform for SimulatorPlatform {
         None
     }
 
-    fn host_device_paths(&self) -> Vec<&'static str> {
+    fn host_cc_device_paths(&self) -> Vec<&'static str> {
         Vec::new()
     }
 

--- a/vsock-proxy/parent/src/platform/simulator.rs
+++ b/vsock-proxy/parent/src/platform/simulator.rs
@@ -15,8 +15,8 @@ impl QemuPlatform for SimulatorPlatform {
         None
     }
 
-    fn guest_device_path(&self) -> Option<&'static str> {
-        None
+    fn host_device_paths(&self) -> Vec<&'static str> {
+        Vec::new()
     }
 
     fn cpu(&self) -> String {

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -56,7 +56,7 @@ impl QemuPlatform for SnpPlatform {
         Some(OVMF_PATH)
     }
 
-    fn host_device_paths(&self) -> Vec<&'static str> {
+    fn host_cc_device_paths(&self) -> Vec<&'static str> {
         vec!["/dev/sev"]
     }
 

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -56,8 +56,8 @@ impl QemuPlatform for SnpPlatform {
         Some(OVMF_PATH)
     }
 
-    fn guest_device_path(&self) -> Option<&'static str> {
-        Some("/dev/sev")
+    fn host_device_paths(&self) -> Vec<&'static str> {
+        vec!["/dev/sev"]
     }
 
     fn cpu(&self) -> String {

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -9,7 +9,6 @@ use super::{GuestLaunchResult, GuestTasks};
 use crate::platform::qemu::QemuPlatform;
 
 const OVMF_PATH: &str = "/opt/fortanix/enclave-os/OVMF.inteltdx.fd";
-const GUEST_DEV_PATH: &str = "/dev/tdx_guest";
 const MEMORY_BACKEND_ID: &str = "mem0";
 const TDX_ID: &str = "tdx0";
 
@@ -34,8 +33,8 @@ impl QemuPlatform for TdxPlatform {
         Some(OVMF_PATH)
     }
 
-    fn guest_device_path(&self) -> Option<&'static str> {
-        Some(GUEST_DEV_PATH)
+    fn host_device_paths(&self) -> Vec<&'static str> {
+        vec!["/dev/sgx_enclave", "/dev/sgx_provision", "/dev/sgx_vepc"]
     }
 
     fn cpu(&self) -> String {

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -33,7 +33,7 @@ impl QemuPlatform for TdxPlatform {
         Some(OVMF_PATH)
     }
 
-    fn host_device_paths(&self) -> Vec<&'static str> {
+    fn host_cc_device_paths(&self) -> Vec<&'static str> {
         vec!["/dev/sgx_enclave", "/dev/sgx_provision", "/dev/sgx_vepc"]
     }
 


### PR DESCRIPTION
This PR fixes the faulty host device checks in Tdx platform. Also adds minor fix to catch early enclave exits.