### PR TITLE
[RTE-1089] Fixing base images loading flow

### DIFF
--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -232,7 +232,7 @@ impl DockerUtil for DockerDaemon {
                     "Failed pulling image {} from remote repository. {:?}",
                     image.to_string(),
                     err
-                ))
+                ));
             }
             Ok(_) => {}
         }
@@ -264,7 +264,16 @@ impl DockerUtil for DockerDaemon {
                     match output {
                         ImageBuildChunk::Update { stream } => {
                             if let Some(image_name) = stream.strip_prefix("Loaded image: ") {
-                                loaded_image_name = Some(image_name.trim().to_owned());
+                                if loaded_image_name.is_none() {
+                                    loaded_image_name = Some(image_name.trim().to_owned());
+                                } else {
+                                    return Err(format!(
+                                        "Loaded docker image {:?} contains more than one valid images. Previously loaded image was {:?}, while another image is {:?}",
+                                        tar_path,
+                                        loaded_image_name.unwrap(),
+                                        image_name
+                                    ));
+                                }
                             }
                         }
                         _ => (),

--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -15,7 +15,7 @@ use docker_image_reference::{Reference as DockerReference, Reference};
 use futures::StreamExt;
 use log::{debug, error, info, warn};
 use shiplift::container::ContainerCreateInfo;
-use shiplift::image::{BuildParams, ImageDetails, PushOptions};
+use shiplift::image::{BuildParams, ImageBuildChunk, ImageDetails, PushOptions};
 use shiplift::{
     ContainerOptions, Docker, Image, PullOptions, RegistryAuth, RmContainerOptions, TagOptions,
 };
@@ -35,7 +35,7 @@ pub trait DockerUtil: Send + Sync {
         image: &DockerReference<'_>,
     ) -> Result<ImageDetails, String>;
 
-    async fn load_image(&self, tar_path: &str) -> Result<(), String>;
+    async fn load_image(&self, tar_path: &str) -> Result<String, String>;
 
     async fn push_image(&self, image: &ImageWithDetails) -> Result<(), String>;
 
@@ -247,17 +247,28 @@ impl DockerUtil for DockerDaemon {
         ))
     }
 
-    async fn load_image(&self, tar_path: &str) -> Result<(), String> {
+    async fn load_image(&self, tar_path: &str) -> Result<String, String> {
         let tar = fs::File::open(tar_path)
             .map_err(|err| format!("Unable to open image file - {:?} : {:?}", tar_path, err))?;
 
         let reader = Box::from(tar);
         let mut stream = self.docker.images().import(reader);
 
+        let mut loaded_image_name: Option<String> = None;
+
         while let Some(import_result) = stream.next().await {
             match import_result {
                 Ok(output) => {
-                    info!("{:?}", output)
+                    info!("{:?}", output);
+
+                    match output {
+                        ImageBuildChunk::Update { stream } => {
+                            if let Some(image_name) = stream.strip_prefix("Loaded image: ") {
+                                loaded_image_name = Some(image_name.trim().to_owned());
+                            }
+                        }
+                        _ => ()
+                    }
                 }
                 Err(e) => {
                     return Err(format!(
@@ -268,7 +279,10 @@ impl DockerUtil for DockerDaemon {
             }
         }
 
-        Ok(())
+        match loaded_image_name {
+            Some(name) => Ok(name),
+            None => Err(format!("Image loading is completed, but no image is loaded.")),
+        }
     }
 
     async fn push_image(&self, image: &ImageWithDetails) -> Result<(), String> {

--- a/tools/container-converter/src/docker.rs
+++ b/tools/container-converter/src/docker.rs
@@ -267,7 +267,7 @@ impl DockerUtil for DockerDaemon {
                                 loaded_image_name = Some(image_name.trim().to_owned());
                             }
                         }
-                        _ => ()
+                        _ => (),
                     }
                 }
                 Err(e) => {
@@ -281,7 +281,9 @@ impl DockerUtil for DockerDaemon {
 
         match loaded_image_name {
             Some(name) => Ok(name),
-            None => Err(format!("Image loading is completed, but no image is loaded.")),
+            None => Err(format!(
+                "Image loading is completed, but no image is loaded."
+            )),
         }
     }
 

--- a/tools/container-converter/src/image_builder/enclave/nitro.rs
+++ b/tools/container-converter/src/image_builder/enclave/nitro.rs
@@ -178,10 +178,7 @@ impl<'a> EnclaveImageBuilder<'a> {
 
     pub(crate) fn get_enclave_base_details(
         _enclaves_options: &NitroEnclavesConversionRequestOptions,
-    ) -> (String, String) {
-        (
-            env::var("ENCLAVE_IMAGE").unwrap_or(crate::ENCLAVE_IMAGE.to_owned()),
-            crate::ENCLAVE_IMAGE_PATH.to_owned(),
-        )
+    ) -> String {
+        crate::ENCLAVE_IMAGE_PATH.to_owned()
     }
 }

--- a/tools/container-converter/src/image_builder/enclave/simulator.rs
+++ b/tools/container-converter/src/image_builder/enclave/simulator.rs
@@ -45,11 +45,8 @@ impl<'a> EnclaveImageBuilder<'a> {
 
     pub(crate) fn get_enclave_base_details(
         _enclaves_options: &SimulatorEnclavesConversionRequestOptions,
-    ) -> (String, String) {
-        (
-            env::var("ENCLAVE_IMAGE").unwrap_or(crate::ENCLAVE_IMAGE.to_owned()),
-            crate::ENCLAVE_IMAGE_PATH.to_owned(),
-        )
+    ) -> String {
+        crate::ENCLAVE_IMAGE_PATH.to_owned()
     }
 }
 

--- a/tools/container-converter/src/image_builder/enclave/snp.rs
+++ b/tools/container-converter/src/image_builder/enclave/snp.rs
@@ -51,22 +51,12 @@ impl<'a> EnclaveImageBuilder<'a> {
 
     pub(crate) fn get_enclave_base_details(
         enclaves_options: &SNPEnclavesConversionRequestOptions,
-    ) -> (String, String) {
-        let image_name = env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
-            if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
-                crate::ENCLAVE_IMAGE_SNP_GPU.to_owned()
-            } else {
-                crate::ENCLAVE_IMAGE.to_owned()
-            }
-        });
-
-        let image_path = if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
+    ) -> String {
+        if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
             crate::ENCLAVE_GPU_IMAGE_PATH.to_owned()
         } else {
             crate::ENCLAVE_IMAGE_PATH.to_owned()
-        };
-
-        (image_name, image_path)
+        }
     }
 }
 

--- a/tools/container-converter/src/image_builder/enclave/tdx.rs
+++ b/tools/container-converter/src/image_builder/enclave/tdx.rs
@@ -50,22 +50,12 @@ impl<'a> EnclaveImageBuilder<'a> {
         .await
     }
 
-    pub(crate) fn get_enclave_base_details(enclaves_options: &EnclavesOptions) -> (String, String) {
-        let image_name = env::var("ENCLAVE_IMAGE").unwrap_or_else(|_| {
-            if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
-                crate::ENCLAVE_IMAGE_TDX_GPU.to_owned()
-            } else {
-                crate::ENCLAVE_IMAGE.to_owned()
-            }
-        });
-
-        let image_path = if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
+    pub(crate) fn get_enclave_base_details(enclaves_options: &EnclavesOptions) -> String {
+        if enclaves_options.enable_gpu_passthrough.unwrap_or_default() {
             crate::ENCLAVE_GPU_IMAGE_PATH.to_owned()
         } else {
             crate::ENCLAVE_IMAGE_PATH.to_owned()
-        };
-
-        (image_name, image_path)
+        }
     }
 }
 

--- a/tools/container-converter/src/image_builder/mod.rs
+++ b/tools/container-converter/src/image_builder/mod.rs
@@ -76,7 +76,7 @@ mod tests {
             todo!()
         }
 
-        async fn load_image(&self, _tar_path: &str) -> Result<(), String> {
+        async fn load_image(&self, _tar_path: &str) -> Result<String, String> {
             todo!()
         }
 

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -173,10 +173,15 @@ async fn run0(
 ) -> Result<PlatformConversionResponse> {
     validate_request(&conversion_request.request)?;
 
-    let parent_image = env::var("PARENT_IMAGE").unwrap_or(PARENT_IMAGE.to_string());
-    info!("Parent base image is {}", parent_image);
+    let mut parent_image = env::var("PARENT_IMAGE").ok();
+    if let Some(s) = &parent_image {
+        info!("Using parent base image from environment variable: {}", s);
+    } else {
+        info!("Using parent base image from tar file: {}", PARENT_IMAGE_PATH);
+    }
+
     info!("Retrieving requisite images!");
-    get_parent_base_image(&parent_image).await?;
+    get_parent_base_image(&mut parent_image).await?;
 
     let client_image = docker_reference(&conversion_request.request.input_image.name)?;
 
@@ -206,14 +211,23 @@ async fn run0(
 
     info!("Building enclave image!");
     let image_result = {
-        let (enclave_base_image_str, enclave_base_image_path_str) =
+        let enclave_base_image_path_str =
             PlatformEnclaveImageBuilder::get_enclave_base_details(
                 &conversion_request.enclaves_options,
             );
-        info!("Enclave base image is {}", enclave_base_image_str);
 
-        let enclave_base_image =
-            get_enclave_base_image(&enclave_base_image_str, enclave_base_image_path_str).await?;
+        let mut enclave_base_image = env::var("ENCLAVE_IMAGE").ok();
+        if let Some(s) = &enclave_base_image {
+            info!("Using enclave base image from environment variable: {}", s);
+        } else {
+            info!("Using enclave base image from tar file: {}", enclave_base_image_path_str);
+        }
+
+        let enclave_base_image = get_enclave_base_image(
+            &mut enclave_base_image,
+            enclave_base_image_path_str,
+        )
+        .await?;
 
         let user_program_config = create_user_program_config(
             &conversion_request.request.converter_options,
@@ -257,7 +271,7 @@ async fn run0(
 
     let parent_builder = PlatformParentImageBuilder {
         parent_image_builder: ParentImageBuilder {
-            parent_image,
+            parent_image: parent_image.expect("parent_image should not be None at this point"),
             dir: &temp_dir,
         },
         start_options: conversion_request.enclaves_options,
@@ -403,68 +417,114 @@ fn hex_response(arg: &str) -> Result<HexString> {
     })
 }
 
-async fn get_enclave_base_image(image: &str, image_path: String) -> Result<ImageWithDetails<'_>> {
+async fn get_enclave_base_image<'a>(
+    image: &'a mut Option<String>,
+    image_path: String,
+) -> Result<ImageWithDetails<'a>> {
     let username = env_var_or_none("ENCLAVE_IMAGE_USERNAME");
     let password = env_var_or_none("ENCLAVE_IMAGE_PASSWORD");
 
-    get_base_image(&image, image_path, username, password).await
+    get_base_image(image, image_path, username, password).await
 }
 
-async fn get_parent_base_image(image: &str) -> Result<()> {
+async fn get_parent_base_image(image: &mut Option<String>) -> Result<()> {
     let username = env_var_or_none("PARENT_IMAGE_USERNAME");
     let password = env_var_or_none("PARENT_IMAGE_PASSWORD");
 
-    let _ = get_base_image(&image, PARENT_IMAGE_PATH.to_owned(), username, password).await?;
+    let _ = get_base_image(
+        image,
+        PARENT_IMAGE_PATH.to_owned(),
+        username,
+        password,
+    )
+    .await?;
 
     Ok(())
 }
 
-async fn get_base_image(
-    image: &str,
+async fn get_base_image<'a>(
+    image: &'a mut Option<String>,
     base_image_tar_path: String,
     username: Option<String>,
     password: Option<String>,
-) -> Result<ImageWithDetails<'_>> {
+) -> Result<ImageWithDetails<'a>> {
     let auth_config = match (username, password) {
         (Some(username), Some(password)) => Some(AuthConfig { username, password }),
         _ => None,
     };
 
     let repository = DockerDaemon::new(&auth_config);
-    let reference = DockerReference::from_str(&image).map_err(|err| ConverterError {
-        message: format!(
-            "Requisite image {} address has bad format. {:?}",
-            image, err
-        ),
-        kind: ConverterErrorKind::BadRequest,
-    })?;
 
-    let details = match repository.get_local_image_details(&reference).await {
-        Ok(details) => details,
-        Err(message) => {
-            info!(
-                "Failed retrieving requisite {} image from local repository. {:?}",
-                image, message
-            );
+    // If the environment variable is set, try loading it instead
+    if let Some(image_name) = image {
+        let reference = DockerReference::from_str(image_name).map_err(|err| ConverterError {
+            message: format!(
+                "Requisite image {} address has bad format. {:?}",
+                image_name, err
+            ),
+            kind: ConverterErrorKind::BadRequest,
+        })?;
+
+        return match repository.get_local_image_details(&reference).await {
+            Ok(details) => Ok(ImageWithDetails { reference, details }),
+            Err(err) => Err(ConverterError {
+                message: format!(
+                    "Requisite image {} cannot be retrieved. {:?}",
+                    image_name, err
+                ),
+                kind: ConverterErrorKind::BadRequest,
+            }),
+        };
+    } else {
+        *image = Some(
             repository
                 .load_image(&base_image_tar_path)
                 .await
                 .map_err(|message| ConverterError {
-                    message: format!("Failed to load requisite {} image. {:?}", image, message),
+                    message: format!(
+                        "Failed to load requisite {} image. {:?}",
+                        base_image_tar_path, message
+                    ),
                     kind: ConverterErrorKind::DockerLoad,
-                })?;
-            info!("Loaded requisite from backup tar file");
-            repository
-                .get_local_image_details(&reference)
-                .await
-                .map_err(|message| ConverterError {
-                    message: format!("Failed retrieving requisite {} image. {:?}", image, message),
-                    kind: ConverterErrorKind::ImageGet,
-                })?
-        }
-    };
+                })?,
+        );
 
-    Ok(ImageWithDetails { reference, details })
+        let loaded_image_name = image.as_ref().unwrap();
+
+        info!(
+            "Loaded requisite from backup tar file: {}",
+            loaded_image_name
+        );
+
+        let reference =
+            DockerReference::from_str(loaded_image_name).map_err(|err| ConverterError {
+                message: format!(
+                    "Requisite image {} address has bad format. {:?}",
+                    loaded_image_name, err
+                ),
+                kind: ConverterErrorKind::BadRequest,
+            })?;
+
+        let details = match repository.get_local_image_details(&reference).await {
+            Ok(details) => details,
+            Err(message) => {
+                info!(
+                    "Failed retrieving requisite {} image from local repository. {:?}",
+                    loaded_image_name, message
+                );
+
+                return Err(ConverterError {
+                    message: format!(
+                        "Failed retrieving requisite {} image. {:?}",
+                        loaded_image_name, message
+                    ),
+                    kind: ConverterErrorKind::ImageGet,
+                });
+            }
+        };
+
+        Ok(ImageWithDetails { reference, details })
+    }
 }
 
 fn env_var_or_none(var_name: &str) -> Option<String> {

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -177,7 +177,10 @@ async fn run0(
     if let Some(s) = &parent_image {
         info!("Using parent base image from environment variable: {}", s);
     } else {
-        info!("Using parent base image from tar file: {}", PARENT_IMAGE_PATH);
+        info!(
+            "Using parent base image from tar file: {}",
+            PARENT_IMAGE_PATH
+        );
     }
 
     info!("Retrieving requisite images!");
@@ -211,23 +214,22 @@ async fn run0(
 
     info!("Building enclave image!");
     let image_result = {
-        let enclave_base_image_path_str =
-            PlatformEnclaveImageBuilder::get_enclave_base_details(
-                &conversion_request.enclaves_options,
-            );
+        let enclave_base_image_path_str = PlatformEnclaveImageBuilder::get_enclave_base_details(
+            &conversion_request.enclaves_options,
+        );
 
         let mut enclave_base_image = env::var("ENCLAVE_IMAGE").ok();
         if let Some(s) = &enclave_base_image {
             info!("Using enclave base image from environment variable: {}", s);
         } else {
-            info!("Using enclave base image from tar file: {}", enclave_base_image_path_str);
+            info!(
+                "Using enclave base image from tar file: {}",
+                enclave_base_image_path_str
+            );
         }
 
-        let enclave_base_image = get_enclave_base_image(
-            &mut enclave_base_image,
-            enclave_base_image_path_str,
-        )
-        .await?;
+        let enclave_base_image =
+            get_enclave_base_image(&mut enclave_base_image, enclave_base_image_path_str).await?;
 
         let user_program_config = create_user_program_config(
             &conversion_request.request.converter_options,
@@ -431,13 +433,7 @@ async fn get_parent_base_image(image: &mut Option<String>) -> Result<()> {
     let username = env_var_or_none("PARENT_IMAGE_USERNAME");
     let password = env_var_or_none("PARENT_IMAGE_PASSWORD");
 
-    let _ = get_base_image(
-        image,
-        PARENT_IMAGE_PATH.to_owned(),
-        username,
-        password,
-    )
-    .await?;
+    let _ = get_base_image(image, PARENT_IMAGE_PATH.to_owned(), username, password).await?;
 
     Ok(())
 }

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -96,30 +96,7 @@ impl fmt::Display for ConverterError {
 
 impl Error for ConverterError {}
 
-#[cfg(platform = "nitro")]
-const PARENT_IMAGE: &str = "parent-base-nitro";
-
-#[cfg(platform = "snp")]
-const PARENT_IMAGE: &str = "parent-base-snp";
-#[cfg(platform = "tdx")]
-const PARENT_IMAGE: &str = "parent-base-tdx";
-
-#[cfg(platform = "simulator")]
-const PARENT_IMAGE: &str = "parent-base-simulator";
-
 const PARENT_IMAGE_PATH: &str = "parent-base.tar";
-
-#[cfg(any(platform = "nitro", platform = "snp", platform = "tdx"))]
-const ENCLAVE_IMAGE: &str = "enclave-base";
-
-#[cfg(platform = "simulator")]
-const ENCLAVE_IMAGE: &str = "enclave-base-simulator";
-
-#[cfg(platform = "snp")]
-const ENCLAVE_IMAGE_SNP_GPU: &str = "enclave-base-gpu";
-#[cfg(platform = "tdx")]
-const ENCLAVE_IMAGE_TDX_GPU: &str = "enclave-base-gpu";
-
 const ENCLAVE_IMAGE_PATH: &str = "enclave-base.tar";
 
 #[cfg(any(platform = "snp", platform = "tdx"))]
@@ -488,8 +465,8 @@ async fn get_base_image<'a>(
         let loaded_image_name = image.as_ref().unwrap();
 
         info!(
-            "Loaded requisite from backup tar file: {}",
-            loaded_image_name
+            "Loaded image {} from tar file {}",
+            loaded_image_name, base_image_tar_path
         );
 
         let reference =


### PR DESCRIPTION
I noticed that the base image loading in the code is quite convoluted. The current logic is:
1. If environment variable is set, try loading from environment variable first from the host Docker repo
2. If it is not set, use hard-coded image name to try loading it from the host Docker repo
3. If it is still fails, load the tarball, then load again using the hard-coded image name

This creates an issue:
1. If image loading from the environment variable fails, it ignores the error and silently load from the second and third step, which is bad for user as it creates surprises.
2. If the host repo already has an image with the hard-coded name (especially if it pulls `latest` tag), it will load whatever images that already exists in the host repo, eventhough it may have been an outdated image compared to the shipped converter. Again, it creates surprises.
3. If the packaged tarball has different image name and tag, it will again fails when finishing step 3 because the Docker cannot find the hard-coded image name. It happens especially if we have version number as tag in the base images, while the Docker try to load `latest` which may not exist unless user manually or our loader programmatically adds the tag.

Therefore, I propose a change in the flow when loading the base images, which for both parent and enclave base images:
1. If environment variable `PARENT_BASE` or `ENCLAVE_BASE` is set, load from the environment variable and immediately fail if there is no such image in the repo
2. If the environment variable is not set, always load from the tarball, and pick up the image name and tag directly from the tarball. It will also overwrite the existing image with the same name and tag if it is already present but different hashes (Docker does this automatically)

Noteworthy remarks:
1. We can remove hard-coding base image name within the converter which reduces synchronization effort between different platforms and build scripts.
2. Function to load image from `liftship` crate (`images().load()`) unfortunately does not results in the actual loaded image, but only the stream of logs from the Docker daemon. We need to parse the output and find the loaded image name from the log stream.
3. `liftship` crate `Reference` instance (aliased as `DockerReference` in our code) uses a borrowed reference to the input string, which results in some reference trickery in the code to allow returning the `DockerReference` from `load_base_image` function correctly to its caller.