### PR TITLE
[RTE-1102] Fixing build issues in `beta` Branch

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # cargo fmt code
 aca7ced2422e414e7b66a7bafc454196fc688da6
+3d6c5b1cfec3ff3f85a162c804cd1911f4ea88b9

--- a/tools/container-converter/src/image_builder/enclave/mod.rs
+++ b/tools/container-converter/src/image_builder/enclave/mod.rs
@@ -49,9 +49,9 @@ use api_model::converter::{CertificateConfig, ConverterOptions, DsmConfiguration
 use api_model::enclave::EnclaveManifest;
 use api_model::enclave::{CcmBackendUrl, FileSystemConfig, UserConfig};
 #[cfg(any(platform = "snp", platform = "tdx"))]
-use api_model::{ByteUnit, EnclavesOptions};
-#[cfg(any(platform = "snp", platform = "tdx"))]
 use api_model::NvidiaDriverCapability;
+#[cfg(any(platform = "snp", platform = "tdx"))]
+use api_model::{ByteUnit, EnclavesOptions};
 use docker_image_reference::Reference as DockerReference;
 use log::{debug, info, warn};
 use nix::sys::statfs::statfs;
@@ -176,7 +176,6 @@ impl EnclaveSettings {
             cpu_count: enclaves_options.cpu_count,
             #[cfg(any(platform = "snp", platform = "tdx"))]
             mem_size: enclaves_options.mem_size.clone(),
-
         }
     }
 }
@@ -897,7 +896,7 @@ impl<'a> GenericEnclaveImageBuilder<'a> {
                 return Err(ConverterError {
                     message: format!("Failed stat for {}. {:?}", path.display(), err),
                     kind: ConverterErrorKind::BlockFileCreation,
-                })
+                });
             }
         }
 

--- a/vsock-proxy/parent/src/platform/qemu.rs
+++ b/vsock-proxy/parent/src/platform/qemu.rs
@@ -217,3 +217,68 @@ fn require_vfio_device(bdf: &str) -> Result<(), String> {
     let vfio_group_path = format!("/dev/vfio/{group}");
     require_file("VFIO group device", &vfio_group_path)
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    fn parse_args_as_kvp<'a>(args: &[&'a str]) -> HashMap<&'a str, Option<&'a str>> {
+        let mut map = HashMap::<&str, Option<&str>>::new();
+
+        let mut last_arg = None;
+
+        for arg in args {
+            if arg.starts_with("-") {
+                last_arg = Some(arg);
+                map.insert(arg, None);
+            } else {
+                if let Some(key) = last_arg {
+                    map.entry(key).and_modify(|val| *val = Some(arg));
+                    last_arg = None;
+                } else {
+                    panic!();
+                }
+            }
+        }
+        map
+    }
+
+    pub fn diff_args(expected: &[&str], actual: &[&str]) {
+        let expected = parse_args_as_kvp(expected);
+        let actual = parse_args_as_kvp(actual);
+
+        let keys_in_expected = expected.keys().copied().collect::<HashSet<_>>();
+        let keys_in_actual = actual.keys().copied().collect::<HashSet<_>>();
+        let intersect = keys_in_expected
+            .intersection(&keys_in_actual)
+            .copied()
+            .collect::<HashSet<_>>();
+
+        let mut success = true;
+
+        for key in &intersect {
+            if !expected.get(key).unwrap().eq(actual.get(key).unwrap()) {
+                println!(
+                    "Argument {:?} differs between expected and actual: {:?} vs {:?}",
+                    key,
+                    expected.get(key).unwrap(),
+                    actual.get(key).unwrap()
+                );
+                success = false;
+            }
+        }
+
+        for item in keys_in_expected.difference(&intersect) {
+            println!("Present in actual but not in expected: {:?}", item);
+            success = false;
+        }
+
+        for item in keys_in_actual.difference(&intersect) {
+            println!("Present in expected but not in actual: {:?}", item);
+            success = false;
+        }
+
+        assert!(success);
+    }
+}

--- a/vsock-proxy/parent/src/platform/qemu.rs
+++ b/vsock-proxy/parent/src/platform/qemu.rs
@@ -117,7 +117,7 @@ pub(super) trait QemuPlatform {
             "-no-reboot",
             "-nodefaults",
             "-serial",
-            constants::DEFAULT_SERIAL_DEVICE
+            constants::DEFAULT_SERIAL_DEVICE,
         ];
 
         if let Some(firmware_path) = self.firmware_path() {

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -117,6 +117,8 @@ mod tests {
             "-initrd", "/opt/fortanix/enclave-os/initramfs.gz",
             "-append", "console=ttyS0 rdinit=/init loglevel=7",
             "-device", "vhost-vsock-pci,guest-cid=3",
+            "-serial", "mon:stdio",
+            "-nodefaults",
         ];
 
         let platform = SnpPlatform {};

--- a/vsock-proxy/parent/src/platform/snp.rs
+++ b/vsock-proxy/parent/src/platform/snp.rs
@@ -98,7 +98,8 @@ async fn start_snp_guest() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashSet;
+    use crate::platform::qemu::tests::diff_args;
+    use std::iter::FromIterator;
 
     #[test]
     fn test_build_qemu_snp_args() {
@@ -117,10 +118,9 @@ mod tests {
             "-append", "console=ttyS0 rdinit=/init loglevel=7",
             "-device", "vhost-vsock-pci,guest-cid=3",
         ];
-        let expected: Vec<String> = expected.into_iter().map(String::from).collect();
-        let expected: HashSet<String> = expected.into_iter().collect();
+
         let platform = SnpPlatform {};
-        let args: HashSet<String> = platform.build_qemu_args().into_iter().collect();
-        assert_eq!(expected, args, "QEMU args mismatch",);
+        let args: Vec<String> = platform.build_qemu_args().into_iter().collect();
+        diff_args(&expected, &Vec::from_iter(args.iter().map(String::as_str)));
     }
 }

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -89,9 +89,9 @@ async fn start_tdx_guest() -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
+    use crate::platform::qemu::tests::diff_args;
+    use std::iter::FromIterator;
 
     #[test]
     fn test_build_qemu_tdx_args() {
@@ -109,10 +109,8 @@ mod tests {
             "-append", "console=ttyS0 rdinit=/init loglevel=7",
             "-device", "vhost-vsock-pci,guest-cid=3",
         ];
-        let expected: Vec<String> = expected.into_iter().map(String::from).collect();
-        let expected: HashSet<String> = expected.into_iter().collect();
         let platform = TdxPlatform {};
-        let args: HashSet<String> = platform.build_qemu_args().into_iter().collect();
-        assert_eq!(expected, args, "QEMU args mismatched",);
+        let args: Vec<String> = platform.build_qemu_args().into_iter().collect();
+        diff_args(&expected, &Vec::from_iter(args.iter().map(String::as_str)));
     }
 }

--- a/vsock-proxy/parent/src/platform/tdx.rs
+++ b/vsock-proxy/parent/src/platform/tdx.rs
@@ -108,6 +108,8 @@ mod tests {
             "-initrd", "/opt/fortanix/enclave-os/initramfs.gz",
             "-append", "console=ttyS0 rdinit=/init loglevel=7",
             "-device", "vhost-vsock-pci,guest-cid=3",
+            "-serial", "mon:stdio",
+            "-nodefaults",
         ];
         let platform = TdxPlatform {};
         let args: Vec<String> = platform.build_qemu_args().into_iter().collect();


### PR DESCRIPTION
Previous merge was slightly broken and did not pass `sanity.sh` and some unit tests. This PR fixes that.

I am changing the way we perform unit testing of the QEMU args generator, so now it can catch the issue accordingly if the expected and actual arguments differ. I identified new arguments being introduced, which are: `-nodefaults` and `-serial`.