### PR TITLE
[RTE-1109] Dockerfiles Hardening

### DIFF
--- a/docker/enclave-base/Dockerfile
+++ b/docker/enclave-base/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get update && \
         ca-certificates \
         cryptsetup \
         nbd-client \
-        openssl
-RUN apt-get clean && rm -rf /var/lib/apt/lists
+        openssl && \
+    apt-get clean && rm -rf /var/lib/apt/lists

--- a/docker/nitro/Dockerfile
+++ b/docker/nitro/Dockerfile
@@ -7,7 +7,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     cryptsetup-bin \
-    sudo
+    sudo \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 # Copy nitro-cli files
 COPY --from=nitro-cli /etc/nitro_enclaves /etc/nitro_enclaves

--- a/docker/nitro/parent-base/Dockerfile
+++ b/docker/nitro/parent-base/Dockerfile
@@ -62,7 +62,9 @@ RUN apt-get update \
         systemctl \
         strace \
         tcpdump \
-    && apt-get upgrade -y
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 # Copy nitro-cli files
 COPY --from=nitro-cli aws-nitro-enclaves-cli/install/etc/nitro_enclaves /etc/nitro_enclaves

--- a/docker/qemu/parent-base/Dockerfile
+++ b/docker/qemu/parent-base/Dockerfile
@@ -14,6 +14,7 @@ ARG QEMU_TARBALL_SHA256
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         bison \
         build-essential \
@@ -33,6 +34,7 @@ RUN apt-get update \
         python3 \
         python3-venv \
         xz-utils \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Download the official QEMU release tarball, verify its SHA-256, then
@@ -118,7 +120,8 @@ RUN apt-get update \
         systemctl \
         tcpdump \
         zlib1g \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 # QEMU built above.
 COPY --from=qemu-builder /opt/qemu /opt/qemu

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -3,11 +3,13 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         cryptsetup-bin \
-        sudo \
-    && rm -rf /var/lib/apt/lists/*
+        sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
 
 RUN mkdir -p /opt/fortanix/enclave-os/blobs
 

--- a/docker/simulator/parent-base/Dockerfile
+++ b/docker/simulator/parent-base/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
         ca-certificates \
         curl  \
         dnsmasq \
@@ -17,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         strace \
         sudo \
         systemctl \
-        tcpdump \
-        && rm -rf /var/lib/apt/lists/*
+        tcpdump && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -15,10 +15,11 @@ RUN apt-get download ovmf && \
     cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
 
 FROM debian:bookworm-slim AS sev_snp_measurement
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
         python3 \
         python3-pip \
         git \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY staging/sev-snp-measure/requirements.txt /tmp/requirements.txt
@@ -29,11 +30,13 @@ ARG NVIDIA_DRIVER_BRANCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         libnvidia-compute-${NVIDIA_DRIVER_BRANCH} \
         nvidia-utils-${NVIDIA_DRIVER_BRANCH} \
         nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
 RUN bash -x /usr/local/bin/stage-nvidia-driver-payload.sh /nvidia-driver-payload
@@ -43,9 +46,12 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
         cryptsetup-bin \
-        python3
+        python3 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
 
 COPY --from=sev_snp_measurement /opt/sev-snp-dist /opt/sev-snp-dist
 ENV PYTHONPATH="/opt/sev-snp-dist"

--- a/docker/tdx/Dockerfile
+++ b/docker/tdx/Dockerfile
@@ -19,10 +19,12 @@ ARG NVIDIA_DRIVER_BRANCH
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         libnvidia-compute-${NVIDIA_DRIVER_BRANCH} \
         nvidia-utils-${NVIDIA_DRIVER_BRANCH} \
         nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
@@ -33,10 +35,13 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y \
         cryptsetup-bin \
-        python3\
-        docker-cli
+        python3 \
+        docker-cli && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Add mising `apt-get upgrade` and `apt-get clean` in Dockerfile.

As discussed with @rui-alm, doing `apt-get update`/`upgrade` in the enclave base image may indeed also upgrade the NVIDIA driver library. We just need to make sure that the kernel driver we compile is synced with the userspace library we package. We may prefer to try pinning the specific minor and revision version as well in our Dockerfile argument, but I think it will cause more confusion and complexity for now.

According to Rui, the risk at the moment is that there is a race condition between the kernel compilation and the Salmiac converter compilation, in which if Canonical publishes a version bump to the NVIDIA drivers in between, the converted image may not work due to the older kernel with newer userspace library. But I think this will be an unlikely situation for now.