### PR TITLE
[RTE-1109] Correcting Nitro Dockerfile `apt-get` command sequences

### DIFF
--- a/docker/enclave-base/Dockerfile
+++ b/docker/enclave-base/Dockerfile
@@ -9,11 +9,12 @@
 
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         ca-certificates \
         cryptsetup \
         nbd-client \
-        openssl && \
-    apt-get clean && rm -rf /var/lib/apt/lists
+        openssl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists

--- a/docker/nitro/Dockerfile
+++ b/docker/nitro/Dockerfile
@@ -4,11 +4,11 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get install -y \
-    cryptsetup-bin \
-    sudo \
+RUN apt-get update \
     && apt-get upgrade -y \
+    && apt-get install -y \
+            cryptsetup-bin \
+            sudo \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists
 

--- a/docker/nitro/parent-base/Dockerfile
+++ b/docker/nitro/parent-base/Dockerfile
@@ -48,6 +48,7 @@ FROM ubuntu:24.04 as parent-base
 # versions of all installed packages at the time the image is built.
 # We do this primarily to pick up security fixes.
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
         curl  \
         dnsmasq \
@@ -62,7 +63,6 @@ RUN apt-get update \
         systemctl \
         strace \
         tcpdump \
-    && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists
 

--- a/docker/nitro/parent-base/Dockerfile
+++ b/docker/nitro/parent-base/Dockerfile
@@ -7,7 +7,8 @@
 FROM ubuntu:24.04 as nitro-cli
 ENV DEBIAN_FRONTEND=noninteractive
 # Install packages for rust toolchain
-RUN apt-get update && apt-get upgrade -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y \
         apt-utils \
         clang \
@@ -36,10 +37,12 @@ RUN rustup target add --toolchain ${RUST_VERSION} x86_64-unknown-linux-musl
 # Install nitro-cli. Use vendored version of openssl since various crates use openssl-sys 0.9 which
 # works only with openssl1. RTE-386
 ENV NITRO_CLI_INSTALL_DIR=./install
-RUN git clone https://github.com/aws/aws-nitro-enclaves-cli.git && \
-    cd aws-nitro-enclaves-cli && \
-    git checkout v1.4.2 && \
-    make nitro-cli-native && make vsock-proxy-native && make install-tools
+RUN git clone https://github.com/aws/aws-nitro-enclaves-cli.git \
+    && cd aws-nitro-enclaves-cli \
+    && git checkout v1.4.2 \
+    && make nitro-cli-native \
+    && make vsock-proxy-native \
+    && make install-tools
 
 # Final image build.
 FROM ubuntu:24.04 as parent-base

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -2,14 +2,14 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
         cryptsetup-bin \
-        sudo && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
+        sudo \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 RUN mkdir -p /opt/fortanix/enclave-os/blobs
 

--- a/docker/simulator/enclave-base/Dockerfile
+++ b/docker/simulator/enclave-base/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         bash \
         busybox-static \
         ca-certificates \
@@ -22,6 +22,5 @@ RUN apt-get update && \
         sed \
         strace \
         util-linux \
-        && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/simulator/parent-base/Dockerfile
+++ b/docker/simulator/parent-base/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl  \
         dnsmasq \
@@ -19,8 +19,8 @@ RUN apt-get update && \
         strace \
         sudo \
         systemctl \
-        tcpdump && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+        tcpdump \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -6,16 +6,18 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update
 
 RUN mkdir -p /blob
 
-RUN apt-get download systemd-boot-efi && \
-    dpkg -x systemd-boot-efi*.deb system_boot_efi_dir && \
-    cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
+RUN apt-get download systemd-boot-efi \
+    && dpkg -x systemd-boot-efi*.deb system_boot_efi_dir \
+    && cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
 
-RUN apt-get download ovmf && \
-    dpkg -x ovmf*.deb ovmf_dir && \
-    cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
+RUN apt-get download ovmf \
+    && dpkg -x ovmf*.deb ovmf_dir \
+    && cp ovmf_dir/usr/share/ovmf/OVMF.amdsev.fd /blob
 
 FROM debian:bookworm-slim AS sev_snp_measurement
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         python3 \
         python3-pip \
         git \
@@ -29,14 +31,14 @@ FROM ubuntu:24.04 AS nvidia_userspace
 ARG NVIDIA_DRIVER_BRANCH
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         libnvidia-compute-${NVIDIA_DRIVER_BRANCH} \
         nvidia-utils-${NVIDIA_DRIVER_BRANCH} \
-        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
+        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
 RUN bash -x /usr/local/bin/stage-nvidia-driver-payload.sh /nvidia-driver-payload
@@ -45,13 +47,13 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         cryptsetup-bin \
-        python3 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
+        python3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists
 
 COPY --from=sev_snp_measurement /opt/sev-snp-dist /opt/sev-snp-dist
 ENV PYTHONPATH="/opt/sev-snp-dist"

--- a/docker/tdx/Dockerfile
+++ b/docker/tdx/Dockerfile
@@ -6,26 +6,26 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update
 
 RUN mkdir -p /blob
 
-RUN apt-get download systemd-boot-efi && \
-    dpkg -x systemd-boot-efi*.deb system_boot_efi_dir && \
-    cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
+RUN apt-get download systemd-boot-efi \
+    && dpkg -x systemd-boot-efi*.deb system_boot_efi_dir \
+    && cp system_boot_efi_dir/usr/lib/systemd/boot/efi/linuxx64.efi.stub /blob
 
-# RUN apt-get download ovmf-inteltdx && \
-#    dpkg -x ovmf*.deb ovmf_dir && \
-#    cp ovmf_dir/usr/share/ovmf/OVMF.inteltdx.fd /blob
+# RUN apt-get download ovmf-inteltdx \
+#     && dpkg -x ovmf*.deb ovmf_dir \
+#     && cp ovmf_dir/usr/share/ovmf/OVMF.inteltdx.fd /blob
 
 FROM ubuntu:24.04 AS nvidia_userspace
 ARG NVIDIA_DRIVER_BRANCH
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
         libnvidia-compute-${NVIDIA_DRIVER_BRANCH} \
         nvidia-utils-${NVIDIA_DRIVER_BRANCH} \
-        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
 RUN bash -x /usr/local/bin/stage-nvidia-driver-payload.sh /nvidia-driver-payload
@@ -34,14 +34,14 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
         cryptsetup-bin \
         python3 \
-        docker-cli && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+        docker-cli \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Nitro Dockerfile has a wrong ordering to update-upgrade-install pattern. Fixing it to align with the rest of the other Dockerfile.