### PR TITLE
[RTE-1138] Update AWS nitro blobs - includes a kernel update

### DIFF
--- a/make/defs.make
+++ b/make/defs.make
@@ -6,7 +6,7 @@
 # defaults.make so they can be included earlier than this file.
 
 DOCKER_REGISTRY := 513076507034.dkr.ecr.us-west-1.amazonaws.com
-ENCLAVE-KERNEL-TAR := amzn-linux-nbd-v3.tar
+ENCLAVE-KERNEL-TAR := amzn-linux-nbd-v4.tar
 
 # Definitions related to string management
 PY_STRING_TABLE := $(REPO_ROOT)/strings/generated_string_table.py


### PR DESCRIPTION
The blobs were built from this branch and published to s3 for use - https://github.com/fortanix/aws-nitro-enclaves-sdk-bootstrap/pull/2
