### PR TITLE
MAL-10700 - Update dependencies for CoCo upstream integration (changing 'libnvidia-ml.so' to 'libnvidia-ml.so.1' inside stage-nvidia-driver-payload.sh)

### DIFF
--- a/docker/snp/stage-nvidia-driver-payload.sh
+++ b/docker/snp/stage-nvidia-driver-payload.sh
@@ -137,7 +137,7 @@ compute_libs=(
 )
 
 utility_libs=(
-  libnvidia-ml.so
+  libnvidia-ml.so.1
   # libnvidia-cfg.so
   # libnvidia-nscq.so
 )

--- a/docker/tdx/stage-nvidia-driver-payload.sh
+++ b/docker/tdx/stage-nvidia-driver-payload.sh
@@ -137,7 +137,7 @@ compute_libs=(
 )
 
 utility_libs=(
-  libnvidia-ml.so
+  libnvidia-ml.so.1
   # libnvidia-cfg.so
   # libnvidia-nscq.so
 )


### PR DESCRIPTION
MAL-10700 - Update dependencies for CoCo upstream integration (changing 'libnvidia-ml.so' to 'libnvidia-ml.so.1' inside stage-nvidia-driver-payload.sh for snp/tdx)

This change is needed because the following change was made in the nvml-wrapper repository as part of MAL-10700: https://github.com/fortanix/nvml-wrapper/pull/4