### PR TITLE
[RTE-1154] Filter Hosts file before writing to Enclave Host file

### DIFF
--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -42,8 +42,8 @@ use futures::{AsyncBufReadExt, StreamExt};
 use log::{debug, error, info, warn};
 use nix::net::if_::if_nametoindex;
 use shared::models::{
-    ApplicationConfiguration, GlobalNetworkSettings, NBDConfiguration, NetworkDeviceSettings,
-    PrivateNetworkDeviceSettings, SetupMessages, UserProgramExitStatus,
+    ApplicationConfiguration, GlobalNetworkSettings, HostEntries, NBDConfiguration,
+    NetworkDeviceSettings, PrivateNetworkDeviceSettings, SetupMessages, UserProgramExitStatus,
 };
 use shared::netlink::arp::NetlinkARP;
 use shared::netlink::route::NetlinkRoute;
@@ -82,7 +82,7 @@ const CERT_RENEWAL_INTERVAL_RELEASE: Duration =
     Duration::from_secs(24 * 60 * 60 /* 24 hours */);
 const CERT_RENEWAL_INTERVAL_DEBUG: Duration = Duration::from_secs(20 /* 20 sec */);
 
-const NETWORK_FILE_PATH_ALLOW_LIST: [&str; 3] = [DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE];
+const NETWORK_FILE_PATH_ALLOW_LIST: [&str; 2] = [DNS_RESOLV_FILE, HOSTNAME_FILE];
 
 fn default_cert_dir() -> PathBuf {
     PathBuf::from(ENCLAVE_FS_OVERLAY_ROOT)
@@ -839,6 +839,7 @@ async fn setup_enclave_networking(
         .map_err(|err| format!("Failed creating /run/resolvconf. {:?}", err))?;
 
     write_network_files(&global_settings, &NETWORK_FILE_PATH_ALLOW_LIST)?;
+    write_hosts_file(&global_settings.host_entries)?;
     debug!("Enclave global network settings files have been created.");
 
     enable_loopback_network_interface()?;
@@ -847,6 +848,25 @@ async fn setup_enclave_networking(
         hostname: global_settings.hostname,
         tap_devices,
     })
+}
+
+fn write_hosts_file(host_entries: &HostEntries) -> Result<(), String> {
+    let mut output = String::from(
+        "127.0.0.1\tlocalhost\n\
+            ::1\tlocalhost ip6-localhost ip6-loopback\n\
+            fe00::\tip6-localnet\n\
+            ff00::\tip6-mcastprefix\n\
+            ff02::1\tip6-allnodes\n\
+            ff02::2\tip6-allrouters\n",
+    );
+    for (ip, hostnames) in host_entries {
+        output.push_str(&ip.to_string());
+        output.push('\t');
+        output.push_str(&hostnames.join(" "));
+        output.push('\n');
+    }
+    write_to_file(Path::new(&HOSTS_FILE), &output, &HOSTS_FILE)?;
+    Ok(())
 }
 
 fn write_network_files(
@@ -1132,6 +1152,7 @@ pub(crate) fn write_to_file<C: AsRef<[u8]> + ?Sized>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::fs::File;
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::Path;
@@ -1238,6 +1259,7 @@ mod tests {
         }
         let global_settings = GlobalNetworkSettings {
             hostname: String::new(),
+            host_entries: HashMap::new(),
             global_settings_list: files,
         };
 

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -857,16 +857,10 @@ fn is_valid_hostname(host: &str) -> bool {
 
     // Rules according to https://man7.org/linux/man-pages/man5/hostname.5.html
     let host_bytes = host.as_bytes();
-    if host_bytes.is_empty() {
-        return false;
-    }
-
-    if !host_bytes[0].is_ascii_alphabetic() {
-        return false;
-    }
-
-    if !host_bytes[host_bytes.len() - 1].is_ascii_alphanumeric() {
-        return false;
+    match (host_bytes.first(), host_bytes.last()) {
+        (Some(first), Some(last))
+            if first.is_ascii_alphabetic() && last.is_ascii_alphanumeric() => {}
+        _ => return false,
     }
 
     host_bytes

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -52,7 +52,7 @@ use shared::socket::{AsyncReadLvStream, AsyncVsockStream as ParentStream, AsyncW
 use shared::tap::{create_async_tap_device, start_tap_loops, tap_device_config};
 use shared::{
     cleanup_tokio_tasks, extract_enum_value, with_background_tasks, AppLogPortInfo, StreamType,
-    DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, VSOCK_PARENT_CID,
+    DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, RESTRICTED_HOSTS, VSOCK_PARENT_CID,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -850,6 +850,30 @@ async fn setup_enclave_networking(
     })
 }
 
+fn is_valid_hostname(host: &str) -> bool {
+    if RESTRICTED_HOSTS.contains(&host) {
+        return false;
+    }
+
+    // Rules according to https://man7.org/linux/man-pages/man5/hostname.5.html
+    let host_bytes = host.as_bytes();
+    if host_bytes.is_empty() {
+        return false;
+    }
+
+    if !host_bytes[0].is_ascii_alphabetic() {
+        return false;
+    }
+
+    if !host_bytes[host_bytes.len() - 1].is_ascii_alphanumeric() {
+        return false;
+    }
+
+    host_bytes
+        .iter()
+        .all(|&b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.')
+}
+
 fn write_hosts_file(host_entries: &HostEntries) -> Result<(), String> {
     let mut output = String::from(
         "127.0.0.1\tlocalhost\n\
@@ -860,10 +884,21 @@ fn write_hosts_file(host_entries: &HostEntries) -> Result<(), String> {
             ff02::2\tip6-allrouters\n",
     );
     for (ip, hostnames) in host_entries {
-        output.push_str(&ip.to_string());
-        output.push('\t');
-        output.push_str(&hostnames.join(" "));
-        output.push('\n');
+        let mut filtered_hosts = hostnames.iter().filter(|host| is_valid_hostname(host));
+
+        // write ip, only if there is any one valid hostname
+        if let Some(first_entry) = filtered_hosts.next() {
+            output.push_str(&ip.to_string());
+            output.push('\t');
+            output.push_str(first_entry);
+
+            // write remaining hosts
+            for host in filtered_hosts {
+                output.push(' ');
+                output.push_str(host);
+            }
+            output.push('\n');
+        }
     }
     write_to_file(Path::new(&HOSTS_FILE), &output, &HOSTS_FILE)?;
     Ok(())
@@ -1170,7 +1205,7 @@ mod tests {
     use tokio::runtime::Runtime;
 
     use crate::enclave::{
-        write_network_files, FileSystemSetupApi, FileSystemSetupConfig,
+        is_valid_hostname, write_network_files, FileSystemSetupApi, FileSystemSetupConfig,
         NETWORK_FILE_PATH_ALLOW_LIST,
     };
 
@@ -1280,6 +1315,21 @@ mod tests {
     fn assert_network_files_allowlist() {
         assert!(!NETWORK_FILE_PATH_ALLOW_LIST.contains(&"/etc/nsswitch.conf"),
             "nsswitch.conf can be used to swap name resolution priority and should not be configurable by the parent.");
+    }
+
+    #[test]
+    fn verify_host_names() {
+        // valid
+        assert!(is_valid_hostname("a"));
+        assert!(is_valid_hostname("fortanix.com"));
+        assert!(is_valid_hostname("fortanix-com"));
+        assert!(is_valid_hostname("fortanix-123.local1"));
+
+        // invalid
+        assert!(!is_valid_hostname("localhost"));
+        assert!(!is_valid_hostname("127.0.0.1"));
+        assert!(!is_valid_hostname("-inccorect-host"));
+        assert!(!is_valid_hostname("host_name"));
     }
 }
 

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -52,7 +52,8 @@ use shared::socket::{AsyncReadLvStream, AsyncVsockStream as ParentStream, AsyncW
 use shared::tap::{create_async_tap_device, start_tap_loops, tap_device_config};
 use shared::{
     cleanup_tokio_tasks, extract_enum_value, with_background_tasks, AppLogPortInfo, StreamType,
-    DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, RESTRICTED_HOSTS, VSOCK_PARENT_CID,
+    DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE, MAX_HOSTNAME_LABEL_LEN, MAX_HOSTNAME_LEN,
+    RESTRICTED_HOSTS, VSOCK_PARENT_CID,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -851,21 +852,39 @@ async fn setup_enclave_networking(
 }
 
 fn is_valid_hostname(host: &str) -> bool {
-    if RESTRICTED_HOSTS.contains(&host) {
+    if RESTRICTED_HOSTS.contains(&host) || host.is_empty() || host.len() > MAX_HOSTNAME_LEN {
         return false;
     }
 
-    // Rules according to https://man7.org/linux/man-pages/man5/hostname.5.html
-    let host_bytes = host.as_bytes();
-    match (host_bytes.first(), host_bytes.last()) {
-        (Some(first), Some(last))
-            if first.is_ascii_alphabetic() && last.is_ascii_alphanumeric() => {}
-        _ => return false,
+    // labels are separated by dots ("."). https://datatracker.ietf.org/doc/html/rfc1034
+    let mut last_label = "";
+    for label in host.split('.') {
+        if label.len() > MAX_HOSTNAME_LABEL_LEN {
+            return false;
+        }
+
+        // alphabet (A-Z), digits (0-9), minus sign (-). The first and last character must be an alpha-numeric character
+        // https://datatracker.ietf.org/doc/html/rfc952 + https://datatracker.ietf.org/doc/html/rfc2181#section-11
+        let host_bytes = label.as_bytes();
+
+        match (host_bytes.first(), host_bytes.last()) {
+            (Some(first), Some(last))
+                if first.is_ascii_alphanumeric() && last.is_ascii_alphanumeric() => {}
+            _ => return false,
+        }
+
+        if !host_bytes
+            .iter()
+            .all(|&b| b.is_ascii_alphanumeric() || b == b'-')
+        {
+            return false;
+        }
+        last_label = label;
     }
 
-    host_bytes
-        .iter()
-        .all(|&b| b.is_ascii_alphanumeric() || b == b'-' || b == b'.')
+    // at least the highest-level component label must not be entirely numeric
+    // https://datatracker.ietf.org/doc/html/rfc1123#page-12
+    return !last_label.as_bytes().iter().all(|&b| b.is_ascii_digit());
 }
 
 fn write_hosts_file(host_entries: &HostEntries) -> Result<(), String> {
@@ -1182,7 +1201,6 @@ pub(crate) fn write_to_file<C: AsRef<[u8]> + ?Sized>(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::fs::File;
     use std::net::{IpAddr, Ipv4Addr};
     use std::path::Path;
 
@@ -1318,12 +1336,22 @@ mod tests {
         assert!(is_valid_hostname("fortanix.com"));
         assert!(is_valid_hostname("fortanix-com"));
         assert!(is_valid_hostname("fortanix-123.local1"));
+        assert!(!is_valid_hostname(&format!(
+            "{}.{}.{}.{}",
+            "a".repeat(251),
+            "b".repeat(251),
+            "c".repeat(251),
+            "d".repeat(251)
+        )));
 
         // invalid
+        assert!(!is_valid_hostname(""));
         assert!(!is_valid_hostname("localhost"));
         assert!(!is_valid_hostname("127.0.0.1"));
-        assert!(!is_valid_hostname("-inccorect-host"));
+        assert!(!is_valid_hostname("-incorect-host"));
         assert!(!is_valid_hostname("host_name"));
+        assert!(!is_valid_hostname(&"a".repeat(64)));
+        assert!(!is_valid_hostname(&format!("{}.com", "a".repeat(251))));
     }
 }
 

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -20,7 +20,7 @@ use parent_lib::{
     communicate_certificates, setup_file_system, CertificateApi, NBDExportConfig, NBD_EXPORTS,
 };
 use shared::models::{
-    ApplicationConfiguration, FileWithPath, GlobalNetworkSettings, SetupMessages,
+    ApplicationConfiguration, FileWithPath, GlobalNetworkSettings, HostEntries, SetupMessages,
     UserProgramExitStatus,
 };
 use shared::socket::{AsyncReadLvStream, AsyncWriteLvStream};
@@ -28,7 +28,7 @@ use shared::tap::{start_tap_loops, PRIVATE_TAP_MTU, PRIVATE_TAP_NAME};
 use shared::{
     cleanup_tokio_tasks, run_subprocess, run_subprocess_with_output_setup, with_background_tasks,
     AppLogPortInfo, CommandOutputConfig, StreamType, DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE,
-    VSOCK_LISTENER_CID,
+    RESTRICTED_HOSTS, VSOCK_LISTENER_CID,
 };
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
@@ -697,6 +697,38 @@ fn customize_resolv_conf(nameserver_address: IpNetwork) -> Result<ResolvConfResu
     Ok(result)
 }
 
+fn filter_host_entries(host_entries: String) -> HostEntries {
+    let mut result: HostEntries = HashMap::new();
+    for line in host_entries.lines() {
+        // Filter comments
+        let line = line.split("#").next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut fields = line.split_whitespace();
+        let ip = match fields.next() {
+            Some(value) => match IpAddr::from_str(value) {
+                Ok(ip) => ip,
+                Err(_) => continue,
+            },
+            None => continue,
+        };
+        let hosts: Vec<&str> = fields.collect();
+        if hosts.is_empty() {
+            continue;
+        }
+        // if any restricted host, then reject whole line.
+        if hosts.iter().any(|host| RESTRICTED_HOSTS.contains(host)) {
+            continue;
+        }
+        result
+            .entry(ip)
+            .or_default()
+            .extend(hosts.into_iter().map(String::from));
+    }
+    result
+}
+
 async fn send_global_network_settings(
     nameserver_address: IpNetwork,
     enclave_port: &mut AsyncVsockStream,
@@ -718,12 +750,16 @@ async fn send_global_network_settings(
         .map_err(|err| format!("Failed converting host name to string. {:?}", err))?;
 
     let dns_file = customize_resolv_conf(nameserver_address)?;
-    let hosts_file = read_file(HOSTS_FILE)?;
     let host_name_file = read_file(HOSTNAME_FILE)?;
+
+    let host_entries = fs::read_to_string(HOSTS_FILE)
+        .map_err(|err| format!("Failed reading parent's {:?} file. {:?}", HOSTS_FILE, err))?;
+    let filtered_hosts = filter_host_entries(host_entries);
 
     let network_settings = GlobalNetworkSettings {
         hostname,
-        global_settings_list: vec![dns_file.resolv_conf_file, hosts_file, host_name_file],
+        host_entries: filtered_hosts,
+        global_settings_list: vec![dns_file.resolv_conf_file, host_name_file],
     };
 
     enclave_port
@@ -869,14 +905,15 @@ fn create_rw_block_file(size: u64, path: PathBuf) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::fs::File;
     use std::path::PathBuf;
+    use std::{collections::HashMap, net::IpAddr};
 
     use tempdir::TempDir;
 
     use crate::parent::{
-        create_rw_block_file, filter_parent_env_from_runtime_envs, MIN_RW_BLOCKFILE_SIZE,
+        create_rw_block_file, filter_host_entries, filter_parent_env_from_runtime_envs,
+        MIN_RW_BLOCKFILE_SIZE,
     };
 
     // Create a temporary directory. Create a file of specified size in the directory.
@@ -993,5 +1030,46 @@ mod tests {
 
         // Ensure the key was removed
         assert!(runtime_env_vars.get("MY_VAR").is_none());
+    }
+
+    #[test]
+    fn test_filter_host_entries() {
+        let host_entries = String::from(
+            "
+            127.0.0.1       localhost
+            ::1             localhost ip6-localhost ip6-loopback
+            fe00::          ip6-localnet
+            ff00::          ip6-mcastprefix
+            ff02::1         ip6-allnodes
+            ff02::2         ip6-allrouters
+            172.17.0.2	    675b2c7a7668
+
+            10.0.0.1        localhost
+            # 10.0.0.3        my-service
+            10.0.0.1        another-service
+            10.0.0.2        my-container
+
+            # Comment
+            10.0.0.3        normal-host
+        ",
+        );
+
+        let filtered_entries = filter_host_entries(host_entries);
+
+        assert_eq!(filtered_entries.iter().len(), 4);
+
+        // Check if comments are filtered
+        assert_eq!(
+            filtered_entries.get(&IpAddr::from([10, 0, 0, 3]).into()),
+            Some(&vec!["normal-host".to_string()])
+        );
+
+        // Check if restricted ips are filtered
+        assert_eq!(
+            filtered_entries.get(&IpAddr::from([10, 0, 0, 1]).into()),
+            Some(&vec!["another-service".to_string()])
+        );
+
+        assert!(!filtered_entries.contains_key(&IpAddr::from([127, 0, 0, 1]).into()));
     }
 }

--- a/vsock-proxy/shared/src/lib.rs
+++ b/vsock-proxy/shared/src/lib.rs
@@ -52,6 +52,14 @@ pub const RESTRICTED_HOSTS: &[&str] = &[
     "ip6-allrouters",
 ];
 
+// Maximum length of host should 255 octets (including the seperators) in DNS Wire or 253 chars without trailing `.`
+// https://datatracker.ietf.org/doc/html/rfc2181#section-11
+pub const MAX_HOSTNAME_LEN: usize = 253;
+
+// The length of any one label is limited to between 1 and 63 octets.
+// https://datatracker.ietf.org/doc/html/rfc2181#section-11
+pub const MAX_HOSTNAME_LABEL_LEN: usize = 63;
+
 // The types of std streams which are forwarded from the client
 // application to the parent for better logging
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]

--- a/vsock-proxy/shared/src/lib.rs
+++ b/vsock-proxy/shared/src/lib.rs
@@ -41,6 +41,17 @@ pub const HOSTS_FILE: &'static str = "/etc/hosts";
 // https://man7.org/linux/man-pages/man5/hostname.5.html
 pub const HOSTNAME_FILE: &'static str = "/etc/hostname";
 
+// Restricted Hosts - These can not be passed as dynamic hosts
+pub const RESTRICTED_HOSTS: &[&str] = &[
+    "localhost",
+    "ip6-localhost",
+    "ip6-loopback",
+    "ip6-localnet",
+    "ip6-mcastprefix",
+    "ip6-allnodes",
+    "ip6-allrouters",
+];
+
 // The types of std streams which are forwarded from the client
 // application to the parent for better logging
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]

--- a/vsock-proxy/shared/src/models.rs
+++ b/vsock-proxy/shared/src/models.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::netlink::arp::ARPEntry;
 use crate::netlink::route::{Gateway, Route};
 use crate::AppLogPortInfo;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum SetupMessages {
@@ -83,9 +84,13 @@ pub struct PrivateNetworkDeviceSettings {
     pub mtu: u32,
 }
 
+pub type HostEntries = HashMap<IpAddr, Vec<String>>;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GlobalNetworkSettings {
     pub hostname: String,
+
+    pub host_entries: HostEntries,
 
     pub global_settings_list: Vec<FileWithPath>,
 }


### PR DESCRIPTION
This PR implements filtering of /etc/hosts before writing to enclave.
Procress: Read all entries from /etc/hosts on parent, filter for any restricted hosts and then write the filtered hosts in enclave hosts file.