### PR TITLE
[RTE-1097] Skip mounting and unmounting the tmp dir when it does not exist

### DIFF
--- a/make/subdirs.make
+++ b/make/subdirs.make
@@ -9,5 +9,6 @@ SUBDIRS = \
 	tools/app-test-infra/apps/python-web-server \
 	tools/app-test-infra/apps/java/websphere \
 	tools/app-test-infra/apps/hostname \
+	tools/app-test-infra/apps/hello-world \
 	tools/app-test-infra/apps/salmiac/python-web-server-localhost \
 	tools/app-test-infra/apps/salmiac/bitnami-postgresql \

--- a/tools/container-converter/src/image_builder/enclave/simulator.rs
+++ b/tools/container-converter/src/image_builder/enclave/simulator.rs
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::env;
 use std::path::Path;
 
 use api_model::enclave::{FileSystemConfig, UserConfig};

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -542,7 +542,8 @@ impl<'a> FileSystemSetupApi<'a> for FileSystemSetupApiImpl {
 }
 
 async fn cleanup_fs(encrypted_fs: EncryptedVolume) -> Result<(), String> {
-    unmount_file_system_nodes(FILE_SYSTEM_NODES).await?;
+    let fs_mount_opts = fetch_fs_mount_options()?;
+    unmount_file_system_nodes(FILE_SYSTEM_NODES, fs_mount_opts).await?;
     info!("Unmounted file system nodes.");
 
     unmount_overlay_fs().await?;

--- a/vsock-proxy/enclave/src/file_system.rs
+++ b/vsock-proxy/enclave/src/file_system.rs
@@ -4,14 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::net::IpAddr;
-use std::path::Path;
-
 use enclaveos_encrypted_fs::dsm_key_config::{ClientConnectionInfo, DsmFsOps};
 use enclaveos_encrypted_fs::{EncryptedVolume, DEVICE_MAPPER};
 use log::info;
 use nix::sys::statvfs::FsFlags;
 use shared::run_subprocess;
+use std::net::IpAddr;
+use std::path::Path;
 use tokio::fs;
 
 use crate::certificate::read_root_certificates;
@@ -32,6 +31,7 @@ const DERIVATION_DATA_IV: &str = "salmiac-persiste";
 
 pub struct FsMountOptions {
     pub is_tmp_exec: bool,
+    pub tmp_exists: bool,
 }
 
 pub(crate) enum FileSystemNode {
@@ -62,13 +62,19 @@ pub(crate) async fn mount_file_system_nodes(
                     node_path = node_path
                 );
                 let mut mount_args = vec!["--rbind", node_path, &formatted_mount_point_str];
-                if *node_path == "/tmp" && mount_options.is_tmp_exec {
-                    mount_args.push("-o");
-                    mount_args.push("exec");
-                    // Make the tmp directory of the enclave base image executable first
-                    // since this is the directory that is mounted into client's
-                    // overlay root.
-                    run_mount(&["/tmp", "-o", "remount,exec"]).await?;
+                if *node_path == "/tmp" {
+                    if !mount_options.tmp_exists {
+                        continue;
+                    }
+
+                    if mount_options.is_tmp_exec {
+                        mount_args.push("-o");
+                        mount_args.push("exec");
+                        // Make the tmp directory of the enclave base image executable first
+                        // since this is the directory that is mounted into client's
+                        // overlay root.
+                        run_mount(&["/tmp", "-o", "remount,exec"]).await?;
+                    }
                 }
                 run_mount(&mount_args).await?;
             }
@@ -97,10 +103,22 @@ pub(crate) async fn mount_read_only_file_system() -> Result<(), String> {
 
 pub(crate) fn fetch_fs_mount_options() -> Result<FsMountOptions, String> {
     let ro_only_mnt_tmp_path = Path::new(ENCLAVE_FS_LOWER).join("tmp");
-    let statfs_res = nix::sys::statvfs::statvfs(ro_only_mnt_tmp_path.as_path())
-        .map_err(|e| format!("Unable to obtain stat info on client's tmp fs : {:?}", e))?;
+
+    let statfs_res = match nix::sys::statvfs::statvfs(ro_only_mnt_tmp_path.as_path()) {
+        Ok(result) => Some(result),
+        Err(e) if e.as_errno() == Some(nix::errno::Errno::ENOENT) => None,
+        Err(e) => {
+            return Err(format!(
+                "Unable to obtain stat info on client's tmp fs : {:?}",
+                e
+            ))
+        }
+    };
     Ok(FsMountOptions {
-        is_tmp_exec: !statfs_res.flags().contains(FsFlags::ST_NOEXEC),
+        is_tmp_exec: statfs_res
+            .as_ref()
+            .map_or(false, |statfs| !statfs.flags().contains(FsFlags::ST_NOEXEC)),
+        tmp_exists: statfs_res.is_some(),
     })
 }
 
@@ -325,13 +343,19 @@ pub(crate) async fn unmount_overlay_fs() -> Result<(), String> {
     run_unmount(&["-v", ENCLAVE_FS_OVERLAY_ROOT]).await
 }
 
-pub(crate) async fn unmount_file_system_nodes(nodes: &[FileSystemNode]) -> Result<(), String> {
+pub(crate) async fn unmount_file_system_nodes(
+    nodes: &[FileSystemNode],
+    mount_options: FsMountOptions,
+) -> Result<(), String> {
     for node in nodes {
         match node {
             FileSystemNode::Proc => {
                 run_unmount(&[&format!("{}/proc/", ENCLAVE_FS_OVERLAY_ROOT)]).await?;
             }
             FileSystemNode::TreeNode(node_path) => {
+                if *node_path == "/tmp" && !mount_options.tmp_exists {
+                    continue;
+                }
                 run_unmount(&[
                     "-R",
                     &format!(

--- a/vsock-proxy/enclave/src/file_system.rs
+++ b/vsock-proxy/enclave/src/file_system.rs
@@ -16,7 +16,10 @@ use tokio::fs;
 use crate::certificate::read_root_certificates;
 use crate::certificate::DEFAULT_CERT_DIR;
 use std::sync::Arc;
+#[cfg(not(test))]
 const ENCLAVE_FS_LOWER: &str = "/mnt/lower";
+#[cfg(test)]
+const ENCLAVE_FS_LOWER: &str = "test-dir";
 const ENCLAVE_FS_RW_ROOT: &str = "/mnt/overlayfs";
 const ENCLAVE_FS_UPPER: &str = "/mnt/overlayfs/upper";
 const ENCLAVE_FS_WORK: &str = "/mnt/overlayfs/work";
@@ -390,4 +393,29 @@ async fn run_unmount(args: &[&str]) -> Result<(), String> {
 
 async fn run_mount(args: &[&str]) -> Result<(), String> {
     run_subprocess("/usr/bin/mount", args).await
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::file_system::fetch_fs_mount_options;
+    use crate::file_system::ENCLAVE_FS_LOWER;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn verify_fs_mount_options() {
+        let test_path = Path::new(ENCLAVE_FS_LOWER).join("tmp");
+        fs::create_dir_all(test_path.as_path()).expect("Failed to create directory");
+
+        // Create tmp directory and check fs_mount_options
+        let result = fetch_fs_mount_options().unwrap();
+        assert!(result.tmp_exists);
+        assert!(result.is_tmp_exec);
+
+        // Remove tmp directory and recheck fs_mount_options
+        fs::remove_dir_all(ENCLAVE_FS_LOWER).expect("Failed to remove directory");
+        let result = fetch_fs_mount_options().unwrap();
+        assert!(!result.tmp_exists);
+        assert!(!result.is_tmp_exec);
+    }
 }


### PR DESCRIPTION
This PR implements the following change: skip mounting and unmounting the `tmp` directory when it does not exist.