### PR TITLE
[RTE-1157] Write hostname from GlobalNetworkSettings instead of recieving from parent

### DIFF
--- a/tools/container-converter/src/image_builder/enclave/simulator.rs
+++ b/tools/container-converter/src/image_builder/enclave/simulator.rs
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::env;
 use std::path::Path;
 
 use api_model::enclave::{FileSystemConfig, UserConfig};

--- a/vsock-proxy/enclave/src/enclave.rs
+++ b/vsock-proxy/enclave/src/enclave.rs
@@ -83,7 +83,7 @@ const CERT_RENEWAL_INTERVAL_RELEASE: Duration =
     Duration::from_secs(24 * 60 * 60 /* 24 hours */);
 const CERT_RENEWAL_INTERVAL_DEBUG: Duration = Duration::from_secs(20 /* 20 sec */);
 
-const NETWORK_FILE_PATH_ALLOW_LIST: [&str; 2] = [DNS_RESOLV_FILE, HOSTNAME_FILE];
+const NETWORK_FILE_PATH_ALLOW_LIST: [&str; 1] = [DNS_RESOLV_FILE];
 
 fn default_cert_dir() -> PathBuf {
     PathBuf::from(ENCLAVE_FS_OVERLAY_ROOT)
@@ -840,6 +840,7 @@ async fn setup_enclave_networking(
         .map_err(|err| format!("Failed creating /run/resolvconf. {:?}", err))?;
 
     write_network_files(&global_settings, &NETWORK_FILE_PATH_ALLOW_LIST)?;
+    write_hostname_file(&global_settings.hostname)?;
     write_hosts_file(&global_settings.host_entries)?;
     debug!("Enclave global network settings files have been created.");
 
@@ -914,6 +915,14 @@ fn write_hosts_file(host_entries: &HostEntries) -> Result<(), String> {
         }
     }
     write_to_file(Path::new(&HOSTS_FILE), &output, &HOSTS_FILE)?;
+    Ok(())
+}
+
+fn write_hostname_file(hostname: &str) -> Result<(), String> {
+    if !is_valid_hostname(&hostname) {
+        return Err(format!("Invalid Hostname provided."));
+    }
+    write_to_file(Path::new(&HOSTNAME_FILE), &hostname, &HOSTNAME_FILE)?;
     Ok(())
 }
 

--- a/vsock-proxy/parent/src/parent.rs
+++ b/vsock-proxy/parent/src/parent.rs
@@ -27,8 +27,8 @@ use shared::socket::{AsyncReadLvStream, AsyncWriteLvStream};
 use shared::tap::{start_tap_loops, PRIVATE_TAP_MTU, PRIVATE_TAP_NAME};
 use shared::{
     cleanup_tokio_tasks, run_subprocess, run_subprocess_with_output_setup, with_background_tasks,
-    AppLogPortInfo, CommandOutputConfig, StreamType, DNS_RESOLV_FILE, HOSTNAME_FILE, HOSTS_FILE,
-    RESTRICTED_HOSTS, VSOCK_LISTENER_CID,
+    AppLogPortInfo, CommandOutputConfig, StreamType, DNS_RESOLV_FILE, HOSTS_FILE, RESTRICTED_HOSTS,
+    VSOCK_LISTENER_CID,
 };
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
@@ -733,15 +733,6 @@ async fn send_global_network_settings(
     nameserver_address: IpNetwork,
     enclave_port: &mut AsyncVsockStream,
 ) -> Result<bool, String> {
-    fn read_file(path: &str) -> Result<FileWithPath, String> {
-        fs::read_to_string(path)
-            .map(|e| FileWithPath {
-                path: path.to_string(),
-                data: e.into_bytes(),
-            })
-            .map_err(|err| format!("Failed reading parent's {} file. {:?}", path, err))
-    }
-
     let raw_hostname =
         nix::unistd::gethostname().map_err(|err| format!("Failed reading host name. {:?}", err))?;
 
@@ -750,7 +741,6 @@ async fn send_global_network_settings(
         .map_err(|err| format!("Failed converting host name to string. {:?}", err))?;
 
     let dns_file = customize_resolv_conf(nameserver_address)?;
-    let host_name_file = read_file(HOSTNAME_FILE)?;
 
     let host_entries = fs::read_to_string(HOSTS_FILE)
         .map_err(|err| format!("Failed reading parent's {:?} file. {:?}", HOSTS_FILE, err))?;
@@ -759,7 +749,7 @@ async fn send_global_network_settings(
     let network_settings = GlobalNetworkSettings {
         hostname,
         host_entries: filtered_hosts,
-        global_settings_list: vec![dns_file.resolv_conf_file, host_name_file],
+        global_settings_list: vec![dns_file.resolv_conf_file],
     };
 
     enclave_port


### PR DESCRIPTION
Write hostname from GlobalNetworkSettings instead of recieving from parent.