### PR TITLE
[RTE-932] Harden Parent Base Image

### DIFF
--- a/docker/nitro/parent-base/Dockerfile
+++ b/docker/nitro/parent-base/Dockerfile
@@ -61,11 +61,7 @@ RUN apt-get update \
         kmod \
         libpcap-dev \
         nbd-server \
-        net-tools \
-        sudo \
         systemctl \
-        strace \
-        tcpdump \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists
 

--- a/docker/qemu/parent-base/Dockerfile
+++ b/docker/qemu/parent-base/Dockerfile
@@ -92,10 +92,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 #     kmod
 #
 #   General userspace utilities used by Salmiac tooling:
-#     ca-certificates, curl, jq, sudo, systemctl
+#     ca-certificates
 #
-#   Diagnostics:
-#     strace, tcpdump
+#   Packages that used to be part of parent image but may be moved into
+#   debugging image:
+#
+#     curl, jq, sudo, systemctl, strace, tcpdump
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \

--- a/docker/qemu/parent-base/Dockerfile
+++ b/docker/qemu/parent-base/Dockerfile
@@ -100,11 +100,9 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
         dnsmasq \
         iproute2 \
         iptables \
-        jq \
         kmod \
         libaio1t64 \
         libcap-ng0 \
@@ -115,10 +113,6 @@ RUN apt-get update \
         libslirp0 \
         nbd-server \
         net-tools \
-        strace \
-        sudo \
-        systemctl \
-        tcpdump \
         zlib1g \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists


### PR DESCRIPTION
We are reducing the amount of packages installed in the parent-base to a minimum required. The package removed are related to debugging features that we may want to add separately in a debug converted images later on.