### PR TITLE
[RTE-978]: Replace nvidia ubuntu packages with nvidia-artifacts.

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,4 +1,4 @@
-name: Build and publish Docker Images
+name: Build Docker Images
 
 on:
   push:
@@ -27,7 +27,8 @@ jobs:
       - name: Build docker images
         run: |
           docker build --no-cache docker/enclave-base -t enclave-base
-          docker build --no-cache docker/enclave-base-gpu -t enclave-base-gpu
+          # Disabled due to required artifacts
+          # docker build --no-cache docker/enclave-base-gpu -t enclave-base-gpu
           docker build --no-cache --build-context common-build-context=docker/common-build-context docker/nitro/parent-base -t parent-base-nitro
           docker build --no-cache --build-context common-build-context=docker/common-build-context  docker/qemu/parent-base -t parent-base-qemu
-          docker rmi enclave-base enclave-base-gpu parent-base-nitro parent-base-qemu
+          docker rmi enclave-base parent-base-nitro parent-base-qemu

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 vsock-proxy/target
 enclave-startup/target
 /tools/enclaveos-encrypted-fs/target
+
+# Platform specific, should be copied from artifacts
+docker/common-build-context/nvidia-artifacts.tar.gz

--- a/docker/enclave-base-gpu/Dockerfile
+++ b/docker/enclave-base-gpu/Dockerfile
@@ -8,14 +8,7 @@
 ARG UBUNTU_VERSION=24.04
 
 FROM ubuntu:${UBUNTU_VERSION} AS enclave-base-gpu
-ARG NVIDIA_DRIVER_BRANCH=595
-ARG NVIDIA_DRIVER_BRANCH_PINNED=595.71.05-0ubuntu0.24.04.1
-ARG UBUNTU_SNAPSHOT=20260601T000000Z
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Bootstrap HTTPS trust using the current archive first.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates
 
 # Runtime packages. Groups:
 #
@@ -24,27 +17,19 @@ RUN apt-get update \
 #     cryptsetup      - opens LUKS-encrypted persistent volumes
 #     nbd-client      - mounts the NBD-served disk from the host
 #
-#   NVIDIA userspace driver (matches the guest kernel module version;
-#   kernel-side is not installed from apt here):
-#     libnvidia-compute-${NVIDIA_DRIVER_BRANCH}
-#                     - libcuda.so.1, libnvidia-opencl.so.1,
-#                       libnvidia-ptxjitcompiler.so.1
-#     nvidia-utils-${NVIDIA_DRIVER_BRANCH}
-#                     - nvidia-smi, libnvidia-ml.so.1, libnvidia-cfg.so.1
-# Ubuntu security updates may publish newer NVIDIA libraries and firmware.
-# Because the NVIDIA driver is supplied as a build artifact and requires specific
-# older versions, use a repository snapshot to install the compatible packages.
-RUN echo "APT::Snapshot \"${UBUNTU_SNAPSHOT}\";"  > /etc/apt/apt.conf.d/50snapshot \
-    && apt-get update \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         cryptsetup \
         nbd-client \
-        libnvidia-compute-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-        nvidia-utils-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
         openssl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=common-build-context nvidia-artifacts.tar.gz /
+RUN tar xpf /nvidia-artifacts.tar.gz -C /
+RUN ldconfig
+RUN rm /nvidia-artifacts.tar.gz
 
 # Fail-fast sanity checks. Catch kernel-module leakage from apt
 # dependencies, and verify the two artifacts the workload actually needs.

--- a/docker/enclave-base/Dockerfile
+++ b/docker/enclave-base/Dockerfile
@@ -8,7 +8,8 @@
 # adds the userspace NVIDIA driver bits.
 
 FROM ubuntu:24.04
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y \

--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -26,28 +26,15 @@ COPY staging/sev-snp-measure/requirements.txt /tmp/requirements.txt
 RUN pip install --break-system-packages --target /opt/sev-snp-dist -r /tmp/requirements.txt
 
 FROM ubuntu:24.04 AS nvidia_userspace
-ARG NVIDIA_DRIVER_BRANCH=595
-ARG NVIDIA_DRIVER_BRANCH_PINNED=595.71.05-0ubuntu0.24.04.1
-ARG UBUNTU_SNAPSHOT=20260601T000000Z
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Bootstrap HTTPS trust using the current archive first.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates
-
-# Ubuntu security updates may publish newer NVIDIA libraries and firmware.
-# Because the NVIDIA driver is supplied as a build artifact and requires specific
-# older versions, use a repository snapshot to install the compatible packages.
-RUN echo "APT::Snapshot \"${UBUNTU_SNAPSHOT}\";"  > /etc/apt/apt.conf.d/50snapshot \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libnvidia-compute-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-        nvidia-utils-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
+COPY staging/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
+
+# Extract NVIDIA artifacts into the root filesystem and update the linker cache.
+# The archive follows the directory layout used by the Ubuntu NVIDIA packages.
+RUN tar xpf /nvidia-artifacts.tar.gz -C /
+RUN ldconfig
+
 RUN bash -x /usr/local/bin/stage-nvidia-driver-payload.sh /nvidia-driver-payload
 
 FROM ubuntu:24.04

--- a/docker/snp/Dockerfile
+++ b/docker/snp/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install --break-system-packages --target /opt/sev-snp-dist -r /tmp/requi
 FROM ubuntu:24.04 AS nvidia_userspace
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
-COPY staging/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
+COPY staging/snp/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
 
 # Extract NVIDIA artifacts into the root filesystem and update the linker cache.
 # The archive follows the directory layout used by the Ubuntu NVIDIA packages.

--- a/docker/tdx/Dockerfile
+++ b/docker/tdx/Dockerfile
@@ -13,28 +13,15 @@ RUN apt-get download systemd-boot-efi \
 #     && cp ovmf_dir/usr/share/ovmf/OVMF.inteltdx.fd /blob
 
 FROM ubuntu:24.04 AS nvidia_userspace
-ARG NVIDIA_DRIVER_BRANCH=595
-ARG NVIDIA_DRIVER_BRANCH_PINNED=595.71.05-0ubuntu0.24.04.1
-ARG UBUNTU_SNAPSHOT=20260601T000000Z
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Bootstrap HTTPS trust using the current archive first.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates
-
-# Ubuntu security updates may publish newer NVIDIA libraries and firmware.
-# Because the NVIDIA driver is supplied as a build artifact and requires specific
-# older versions, use a repository snapshot to install the compatible packages.
-RUN echo "APT::Snapshot \"${UBUNTU_SNAPSHOT}\";"  > /etc/apt/apt.conf.d/50snapshot \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libnvidia-compute-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-        nvidia-utils-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-        nvidia-kernel-common-${NVIDIA_DRIVER_BRANCH}=${NVIDIA_DRIVER_BRANCH_PINNED} \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
+COPY staging/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
+
+# Extract NVIDIA artifacts into the root filesystem and update the linker cache.
+# The archive follows the directory layout used by the Ubuntu NVIDIA packages.
+RUN tar xpf /nvidia-artifacts.tar.gz -C /
+RUN ldconfig
+
 RUN bash -x /usr/local/bin/stage-nvidia-driver-payload.sh /nvidia-driver-payload
 
 FROM ubuntu:24.04

--- a/docker/tdx/Dockerfile
+++ b/docker/tdx/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get download systemd-boot-efi \
 FROM ubuntu:24.04 AS nvidia_userspace
 
 COPY stage-nvidia-driver-payload.sh /usr/local/bin/stage-nvidia-driver-payload.sh
-COPY staging/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
+COPY staging/tdx/kernel_enabled_gpu/nvidia-artifacts.tar.gz /
 
 # Extract NVIDIA artifacts into the root filesystem and update the linker cache.
 # The archive follows the directory layout used by the Ubuntu NVIDIA packages.


### PR DESCRIPTION
This PR ends using ubuntu repositories for nvidia packages and uses nvidia-artifacts file instead.

Now `nvidia-artifacts.tar.gz` is expected in `docker/common-builder-context` directory.