### PR TITLE
[RTE-1176] Document unsupported converter options

### DIFF
--- a/api-model/docs/models.openapi.yaml
+++ b/api-model/docs/models.openapi.yaml
@@ -284,12 +284,22 @@ components:
     SNPEnclavesConversionResponse:
       type: "object"
       required:
-        - converted_image
+        - name
+        - sha
+        - size
         - config
       properties:
-        converted_image:
-          $ref: "#/components/schemas/ConvertedImageInfo"
-          description: "Reference properties of the converted image"
+        name:
+          type: "string"
+          description: "Converted image name (with tag)"
+        sha:
+          type: "string"
+          description: "Converted image sha"
+          format: hex
+        size:
+          type: "integer"
+          format: "int64"
+          description: "Converted image size"
         config:
           $ref: "#/components/schemas/SNPEnclavesConfig"
           description: "SNP Enclaves configuration of the converted image"
@@ -352,12 +362,22 @@ components:
     TdxEnclavesConversionResponse:
       type: "object"
       required:
-        - converted_image
+        - name
+        - sha
+        - size
         - config
       properties:
-        converted_image:
-          $ref: "#/components/schemas/ConvertedImageInfo"
-          description: "Reference properties of the converted image"
+        name:
+          type: "string"
+          description: "Converted image name (with tag)"
+        sha:
+          type: "string"
+          description: "Converted image sha"
+          format: hex
+        size:
+          type: "integer"
+          format: "int64"
+          description: "Converted image size"
         config:
           $ref: "#/components/schemas/TdxEnclavesConfig"
           description: "Tdx Enclaves configuration of the converted image"

--- a/api-model/docs/models.openapi.yaml
+++ b/api-model/docs/models.openapi.yaml
@@ -18,22 +18,6 @@ components:
         password:
           type: "string"
           description: "Password for docker registry authentication"
-    CaCertificateConfig:
-      type: "object"
-      properties:
-        ca_path:
-          type: "string"
-          description: "Path to expose the CA cert in the application filesystem"
-        ca_cert:
-          type: "string"
-          description: >
-            Base64-encoded CA certificate contents. Not required when
-            converting applications via Enclave Manager. Required when calling
-            the converter directly, or if you wish to override the Enclave
-            Manager CA certificate.
-        system:
-          type: "string"
-          description: "Request to install CA cert in the system trust store"
     CertificateConfig:
       required:
         - issuer
@@ -62,8 +46,6 @@ components:
           default: Rsa
           enum:
             - Rsa
-          # Not yet supported:
-          #- EC
         key_param:
           type: "object"
           description: >
@@ -72,14 +54,11 @@ components:
         key_path:
           type: "string"
           description: "Path to expose the key in the application filesystem"
-          default: "key"
+          default: "/opt/fortanix/enclave-os/default_cert/app_private.pem"
         cert_path:
           type: "string"
           description: "Path to expose the certificate in the application filesystem"
-          default: "cert"
-        chain_path:
-          type: "string"
-          description: "Path to expose the complete certificate chain in the application filesystem"
+          default: "/opt/fortanix/enclave-os/default_cert/app_public.pem"
     ConvertedImageInfo:
       type: object
       required:
@@ -101,22 +80,10 @@ components:
     ConverterOptions:
       type: "object"
       properties:
-        allow_cmdline_args:
-          type: "boolean"
-          description: "Allow command line arguments to EnclaveOS application"
-        allow_docker_pull_failure:
-          type: "boolean"
-          description: "Allow Docker Pull failure."
-        app:
-          type: "object"
         certificates:
           type: "array"
           items:
             $ref: "#/components/schemas/CertificateConfig"
-        ca_certificates:
-          type: "array"
-          items:
-            $ref: "#/components/schemas/CaCertificateConfig"
         debug:
           type: "boolean"
           description: "Enables debug logging from EnclaveOS"
@@ -141,9 +108,6 @@ components:
           items:
             type: string
           type: array
-        java_mode:
-          type: "string"
-          description: "Type of the Java JVM used"
         enable_overlay_filesystem_persistence:
           type: "boolean"
           default: false
@@ -320,22 +284,12 @@ components:
     SNPEnclavesConversionResponse:
       type: "object"
       required:
-        - name
-        - sha
-        - size
+        - converted_image
         - config
       properties:
-        name:
-          type: "string"
-          description: "Converted image name (with tag)"
-        sha:
-          type: "string"
-          description: "Converted image sha"
-          format: hex
-        size:
-          type: "integer"
-          format: "int64"
-          description: "Converted image size"
+        converted_image:
+          $ref: "#/components/schemas/ConvertedImageInfo"
+          description: "Reference properties of the converted image"
         config:
           $ref: "#/components/schemas/SNPEnclavesConfig"
           description: "SNP Enclaves configuration of the converted image"
@@ -398,22 +352,12 @@ components:
     TdxEnclavesConversionResponse:
       type: "object"
       required:
-        - name
-        - sha
-        - size
+        - converted_image
         - config
       properties:
-        name:
-          type: "string"
-          description: "Converted image name (with tag)"
-        sha:
-          type: "string"
-          description: "Converted image sha"
-          format: hex
-        size:
-          type: "integer"
-          format: "int64"
-          description: "Converted image size"
+        converted_image:
+          $ref: "#/components/schemas/ConvertedImageInfo"
+          description: "Reference properties of the converted image"
         config:
           $ref: "#/components/schemas/TdxEnclavesConfig"
           description: "Tdx Enclaves configuration of the converted image"

--- a/tools/container-converter/src/lib.rs
+++ b/tools/container-converter/src/lib.rs
@@ -86,6 +86,7 @@ pub enum ConverterErrorKind {
     BadCcmConfiguration,
     BadDsmConfiguration,
     DockerLoad,
+    UnsupportedConfig,
 }
 
 impl fmt::Display for ConverterError {
@@ -309,7 +310,7 @@ fn validate_request(request: &ConversionRequest) -> Result<()> {
 
             if let Some(_s) = &cert_settings.chain_path {
                 return Err(ConverterError {
-                    message: "Chain path is not supported on this platform yet".to_string(),
+                    message: "Chain path is not supported on this platform".to_string(),
                     kind: ConverterErrorKind::BadCertConfig,
                 });
             }
@@ -318,7 +319,7 @@ fn validate_request(request: &ConversionRequest) -> Result<()> {
 
     if !request.converter_options.ca_certificates.is_empty() {
         return Err(ConverterError {
-            message: "CA certificates are not supported on this platform yet".to_string(),
+            message: "CA certificates are not supported on this platform".to_string(),
             kind: ConverterErrorKind::BadCertConfig,
         });
     }
@@ -339,6 +340,34 @@ fn validate_request(request: &ConversionRequest) -> Result<()> {
                 kind: ConverterErrorKind::BadDsmConfiguration,
             });
         }
+    }
+
+    if let Some(_) = &request.converter_options.allow_cmdline_args {
+        return Err(ConverterError {
+            message: "allow_cmdline_args is not supported on this platform".to_string(),
+            kind: ConverterErrorKind::UnsupportedConfig,
+        });
+    }
+
+    if let Some(_) = &request.converter_options.allow_docker_pull_failure {
+        return Err(ConverterError {
+            message: "allow_docker_pull_failure is not supported on this platform".to_string(),
+            kind: ConverterErrorKind::UnsupportedConfig,
+        });
+    }
+
+    if let Some(_) = &request.converter_options.app {
+        return Err(ConverterError {
+            message: "app is not supported on this platform".to_string(),
+            kind: ConverterErrorKind::UnsupportedConfig,
+        });
+    }
+
+    if let Some(_) = &request.converter_options.java_mode {
+        return Err(ConverterError {
+            message: "java_mode is not supported on this platform".to_string(),
+            kind: ConverterErrorKind::UnsupportedConfig,
+        });
     }
 
     Ok(())
@@ -869,7 +898,7 @@ mod tests {
         let converter_error = res.expect_err("");
         assert!(converter_error
             .message
-            .contains("Chain path is not supported on this platform yet"));
+            .contains("Chain path is not supported on this platform"));
         assert!(converter_error.kind == ConverterErrorKind::BadCertConfig);
     }
 
@@ -887,7 +916,7 @@ mod tests {
         let converter_error = res.expect_err("");
         assert!(converter_error
             .message
-            .contains("CA certificates are not supported on this platform yet"));
+            .contains("CA certificates are not supported on this platform"));
         assert_eq!(converter_error.kind, ConverterErrorKind::BadCertConfig);
     }
 
@@ -951,6 +980,77 @@ mod tests {
             dsm_url: "https://someregion.smartkey.io".to_string(),
         });
         assert!(validate_request(&request).is_ok());
+    }
+
+    #[test]
+    fn validate_converter_request_unsupported_configs() -> () {
+        let mut request = SAMPLE_REQUEST.clone();
+
+        // Test 1 - allow_cmdline_args is set to Some
+        request.converter_options.allow_cmdline_args = Some(true);
+        let res = validate_request(&request);
+        assert!(res.is_err());
+
+        let converter_error = res.expect_err("");
+        assert_eq!(
+            converter_error.message,
+            "allow_cmdline_args is not supported on this platform"
+        );
+        assert_eq!(converter_error.kind, ConverterErrorKind::UnsupportedConfig);
+
+        // Test 2 - allow_cmdline_args is set to None
+        request.converter_options.allow_cmdline_args = None;
+        assert!(validate_request(&request).is_ok());
+
+        // Test 3 - allow_docker_pull_failure is set to false
+        request.converter_options.allow_docker_pull_failure = Some(false);
+        let res = validate_request(&request);
+        assert!(res.is_err());
+
+        let converter_error = res.expect_err("");
+        assert_eq!(
+            converter_error.message,
+            "allow_docker_pull_failure is not supported on this platform"
+        );
+        assert_eq!(converter_error.kind, ConverterErrorKind::UnsupportedConfig);
+
+        // Test 4 - allow_docker_pull_failure is set to true
+        request.converter_options.allow_docker_pull_failure = Some(true);
+        let res = validate_request(&request);
+        assert!(res.is_err());
+
+        let converter_error = res.expect_err("");
+        assert_eq!(
+            converter_error.message,
+            "allow_docker_pull_failure is not supported on this platform"
+        );
+        assert_eq!(converter_error.kind, ConverterErrorKind::UnsupportedConfig);
+
+        // Test 5 - app is set to Some
+        request.converter_options.allow_docker_pull_failure = None;
+        request.converter_options.app = Some(Value::from("some-app"));
+        let res = validate_request(&request);
+        assert!(res.is_err());
+
+        let converter_error = res.expect_err("");
+        assert_eq!(
+            converter_error.message,
+            "app is not supported on this platform"
+        );
+        assert_eq!(converter_error.kind, ConverterErrorKind::UnsupportedConfig);
+
+        // Test 6 - java_mode is set to Some
+        request.converter_options.app = None;
+        request.converter_options.java_mode = Some("oracle-jvm".to_string());
+        let res = validate_request(&request);
+        assert!(res.is_err());
+
+        let converter_error = res.expect_err("");
+        assert_eq!(
+            converter_error.message,
+            "java_mode is not supported on this platform"
+        );
+        assert_eq!(converter_error.kind, ConverterErrorKind::UnsupportedConfig);
     }
 }
 


### PR DESCRIPTION
- Cleanup and update converter's openapi documentation
- Include error messages and unit tests for unsupported configurations available. 